### PR TITLE
refactor mock and Tests users me patch

### DIFF
--- a/src/__mocks__/mockedDb/bug.ts
+++ b/src/__mocks__/mockedDb/bug.ts
@@ -19,6 +19,11 @@ export const table = {
 
 type BugParams = {
   id?: number;
+  message?: string;
+  campaign_id?: number;
+  status_id?: number;
+  wp_user_id?: number;
+  severity_id?: number;
 };
 const data: {
   [key: string]: (params?: BugParams) => Promise<{ [key: string]: any }>;
@@ -26,6 +31,16 @@ const data: {
   drop: async () => {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
+};
+
+data.basicBug = async (params) => {
+  const item = {
+    id: 1,
+    wp_user_id: 1,
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
 };
 
 export { data };

--- a/src/__mocks__/mockedDb/certificationList.ts
+++ b/src/__mocks__/mockedDb/certificationList.ts
@@ -15,17 +15,32 @@ export const table = {
   },
 };
 
-type UsersDeletionReasonParams = {
-  ID?: number;
+type CertificationParams = {
+  id?: number;
+  name?: string;
+  area?: string;
+  institute?: string;
 };
 const data: {
   [key: string]: (
-    params?: UsersDeletionReasonParams
+    params?: CertificationParams
   ) => Promise<{ [key: string]: any }>;
 } = {
   drop: async () => {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
+};
+
+data.certification1 = async (params) => {
+  const item = {
+    id: 1,
+    name: "Best Tryber Ever",
+    area: "Testing 360",
+    institute: "Tryber",
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
 };
 
 export { data };

--- a/src/__mocks__/mockedDb/cp_has_candidates.ts
+++ b/src/__mocks__/mockedDb/cp_has_candidates.ts
@@ -1,8 +1,9 @@
 import sqlite3 from "@src/features/sqlite";
 
+const tableName = "wp_crowd_appq_has_candidate";
 export const table = {
   create: async () => {
-    await sqlite3.createTable("wp_crowd_appq_has_candidate", [
+    await sqlite3.createTable(tableName, [
       "user_id INTEGER(11) NOT NULL PRIMARY KEY",
       "campaign_id INTEGER(11)",
       "subscription_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP",
@@ -15,19 +16,30 @@ export const table = {
     ]);
   },
   drop: async () => {
-    await sqlite3.dropTable("wp_crowd_appq_has_candidate");
+    await sqlite3.dropTable(tableName);
   },
+};
+type CandidacyParams = {
+  user_id?: number;
+  campaign_id?: number;
+  subscription_date?: string;
+  accepted?: number;
+  devices?: number;
+  selected_device?: number;
+  results?: number;
+  modified?: string;
+  group_id?: number;
 };
 
 const data: {
-  [key: string]: (params?: any) => Promise<{ [key: string]: any }>;
+  [key: string]: (params?: CandidacyParams) => Promise<{ [key: string]: any }>;
 } = {
   drop: async () => {
-    return await sqlite3.run("DELETE FROM wp_crowd_appq_has_candidate");
+    return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
 };
 
-data.candidate1 = async () => {
+data.candidate1 = async (params) => {
   const item = {
     user_id: 1,
     campaign_id: 1,
@@ -38,8 +50,9 @@ data.candidate1 = async () => {
     results: 0,
     modified: new Date("01/01/2021").toISOString(),
     group_id: 1,
+    ...params,
   };
-  await sqlite3.insert("wp_crowd_appq_has_candidate", item);
+  await sqlite3.insert(tableName, item);
   return item;
 };
 

--- a/src/__mocks__/mockedDb/customUserFields.ts
+++ b/src/__mocks__/mockedDb/customUserFields.ts
@@ -29,4 +29,15 @@ const data: {
   },
 };
 
+data.insertCuf = async (params) => {
+  const item = {
+    id: 1,
+    name: "CUF name",
+    enabled: 1,
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
+};
+
 export { data };

--- a/src/__mocks__/mockedDb/customUserFieldsData.ts
+++ b/src/__mocks__/mockedDb/customUserFieldsData.ts
@@ -19,6 +19,9 @@ export const table = {
 type CUFDataParams = {
   id?: number;
   profile_id?: number;
+  value?: string;
+  custom_user_field_id?: number;
+  candidate?: number;
 };
 const data: {
   [key: string]: (params?: CUFDataParams) => Promise<{ [key: string]: any }>;
@@ -28,4 +31,14 @@ const data: {
   },
 };
 
+data.insertCufData = async (params) => {
+  const item = {
+    id: 1,
+    custom_user_field_id: 1,
+    profile_id: 1,
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
+};
 export { data };

--- a/src/__mocks__/mockedDb/customUserFieldsExtra.ts
+++ b/src/__mocks__/mockedDb/customUserFieldsExtra.ts
@@ -24,5 +24,14 @@ const data: {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
 };
+data.insertCufExtras = async (params) => {
+  const item = {
+    id: 1,
+    name: "Cuf Extra name",
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
+};
 
 export { data };

--- a/src/__mocks__/mockedDb/educationList.ts
+++ b/src/__mocks__/mockedDb/educationList.ts
@@ -13,17 +13,25 @@ export const table = {
   },
 };
 
-type UsersDeletionReasonParams = {
-  ID?: number;
+type EducationParams = {
+  id?: number;
+  display_name?: string;
 };
 const data: {
-  [key: string]: (
-    params?: UsersDeletionReasonParams
-  ) => Promise<{ [key: string]: any }>;
+  [key: string]: (params?: EducationParams) => Promise<{ [key: string]: any }>;
 } = {
   drop: async () => {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
+};
+data.education1 = async (params) => {
+  const item = {
+    id: 1,
+    display_name: "Education name",
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
 };
 
 export { data };

--- a/src/__mocks__/mockedDb/employmentList.ts
+++ b/src/__mocks__/mockedDb/employmentList.ts
@@ -13,17 +13,26 @@ export const table = {
   },
 };
 
-type UsersDeletionReasonParams = {
-  ID?: number;
+type EmploymentParams = {
+  id?: number;
+  display_name?: string;
 };
 const data: {
-  [key: string]: (
-    params?: UsersDeletionReasonParams
-  ) => Promise<{ [key: string]: any }>;
+  [key: string]: (params?: EmploymentParams) => Promise<{ [key: string]: any }>;
 } = {
   drop: async () => {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
+};
+
+data.employment1 = async (params) => {
+  const item = {
+    id: 1,
+    display_name: "Employment name",
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
 };
 
 export { data };

--- a/src/__mocks__/mockedDb/languageList.ts
+++ b/src/__mocks__/mockedDb/languageList.ts
@@ -13,17 +13,25 @@ export const table = {
   },
 };
 
-type UsersDeletionReasonParams = {
-  ID?: number;
+type LanguageParams = {
+  id?: number;
+  display_name?: string;
 };
 const data: {
-  [key: string]: (
-    params?: UsersDeletionReasonParams
-  ) => Promise<{ [key: string]: any }>;
+  [key: string]: (params?: LanguageParams) => Promise<{ [key: string]: any }>;
 } = {
   drop: async () => {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
+};
+data.lenguage1 = async (params) => {
+  const item = {
+    id: 1,
+    display_name: "Language name",
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
 };
 
 export { data };

--- a/src/__mocks__/mockedDb/profile.ts
+++ b/src/__mocks__/mockedDb/profile.ts
@@ -1,4 +1,4 @@
-import sqlite3 from "@src/features/sqlite";
+import sqlite3 from '@src/features/sqlite';
 
 export const table = {
   create: async () => {
@@ -7,11 +7,10 @@ export const table = {
       "name VARCHAR(255)",
       "surname VARCHAR(255)",
       "email VARCHAR(255)",
-      "pending_booty DECIMAL(11,2)",
-      "booty FLOAT(2)",
       "wp_user_id INTEGER ",
       "is_verified INTEGER DEFAULT 0",
-      "last_activity TIMESTAMP",
+      "booty DECIMAL(11,2)",
+      "pending_booty DECIMAL(11,2)",
       "total_exp_pts INTEGER DEFAULT 0",
       "payment_status BOOL",
       "birth_date DATETIME",
@@ -32,6 +31,7 @@ export const table = {
       "country_code VARCHAR(255)",
       "onboarding_complete BOOL",
       "deletion_date TIMESTAMP",
+      "last_activity TIMESTAMP",
     ]);
   },
   drop: async () => {
@@ -44,11 +44,20 @@ type TesterParams = {
   name?: string;
   surname?: string;
   email?: string;
-  pending_booty?: number;
   wp_user_id?: number;
   is_verified?: number;
-  last_activity?: string;
+  booty?: number;
+  pending_booty?: number;
   total_exp_pts?: number;
+  birth_date?: string;
+  phone_number?: string;
+  sex?: number;
+  country?: string;
+  city?: string;
+  onboarding_complete?: number;
+  employment_id?: number;
+  education_id?: number;
+  last_activity?: string;
 };
 const data: {
   [key: string]: (params?: TesterParams) => Promise<{ [key: string]: any }>;

--- a/src/__mocks__/mockedDb/testerCertification.ts
+++ b/src/__mocks__/mockedDb/testerCertification.ts
@@ -15,17 +15,31 @@ export const table = {
   },
 };
 
-type UsersDeletionReasonParams = {
-  ID?: number;
+type TesterHasCertificationParams = {
+  id?: number;
+  tester_id?: number;
+  cert_id?: number;
+  achievement_date?: string;
 };
 const data: {
   [key: string]: (
-    params?: UsersDeletionReasonParams
+    params?: TesterHasCertificationParams
   ) => Promise<{ [key: string]: any }>;
 } = {
   drop: async () => {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
+};
+
+data.assignCertification = async (params) => {
+  const item = {
+    id: 1,
+    tester_id: 1,
+    cert_id: 1,
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
 };
 
 export { data };

--- a/src/__mocks__/mockedDb/testerLanguage.ts
+++ b/src/__mocks__/mockedDb/testerLanguage.ts
@@ -28,5 +28,15 @@ const data: {
     return await sqlite3.run(`DELETE FROM ${tableName}`);
   },
 };
+data.assignLanguage = async (params) => {
+  const item = {
+    id: 1,
+    profile_id: 1,
+    language_id: 1,
+    ...params,
+  };
+  await sqlite3.insert(tableName, item);
+  return item;
+};
 
 export { data };

--- a/src/__mocks__/mockedDb/wp_users.ts
+++ b/src/__mocks__/mockedDb/wp_users.ts
@@ -1,4 +1,4 @@
-import sqlite3 from "@src/features/sqlite";
+import sqlite3 from '@src/features/sqlite';
 
 const tableName = "wp_users";
 export const table = {
@@ -6,6 +6,7 @@ export const table = {
     await sqlite3.createTable(tableName, [
       "ID INTEGER PRIMARY KEY",
       "user_login VARCHAR(255)",
+      "user_email VARCHAR(100)",
     ]);
   },
   drop: async () => {
@@ -15,6 +16,8 @@ export const table = {
 
 type WpUsersParams = {
   ID?: number;
+  user_login?: string;
+  user_email?: string;
 };
 const data: {
   [key: string]: (params?: WpUsersParams) => Promise<{ [key: string]: any }>;

--- a/src/__mocks__/mockedDb/wp_users.ts
+++ b/src/__mocks__/mockedDb/wp_users.ts
@@ -1,4 +1,4 @@
-import sqlite3 from '@src/features/sqlite';
+import sqlite3 from "@src/features/sqlite";
 
 const tableName = "wp_users";
 export const table = {
@@ -7,6 +7,7 @@ export const table = {
       "ID INTEGER PRIMARY KEY",
       "user_login VARCHAR(255)",
       "user_email VARCHAR(100)",
+      "user_pass VARCHAR(255)",
     ]);
   },
   drop: async () => {
@@ -18,6 +19,7 @@ type WpUsersParams = {
   ID?: number;
   user_login?: string;
   user_email?: string;
+  user_pass?: string;
 };
 const data: {
   [key: string]: (params?: WpUsersParams) => Promise<{ [key: string]: any }>;

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,26 +21,10 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const cufTextVal = {
-  //cuf_data
-  id: 1,
-  value: "CiccioGamer89.",
-  custom_user_field_id: 1,
-  profile_id: 1,
-  candidate: 0,
-};
 const cufSelectOption1 = {
   //cuf_exstras
   id: 1,
   name: "Habanero Scorpion",
-};
-const cufSelectTesterOption1 = {
-  //cuf_data
-  id: 2,
-  value: cufSelectOption1.id,
-  custom_user_field_id: 2,
-  profile_id: 1,
-  candidate: 0,
 };
 const cufMultiselect = {
   id: 3,
@@ -56,22 +40,6 @@ const cufMultiSelectVal2 = {
   //cuf_exstras
   id: 3,
   name: "Treviso, città del Cardamomo",
-};
-const cufMultiSelectTesterVal1 = {
-  //cuf_data
-  id: 3,
-  value: cufMultiSelectVal1.id,
-  custom_user_field_id: 3,
-  profile_id: 1,
-  candidate: 0,
-};
-const cufMultiSelectTesterVal2 = {
-  //cuf_data
-  id: 4,
-  value: cufMultiSelectVal2.id,
-  custom_user_field_id: 3,
-  profile_id: 1,
-  candidate: 0,
 };
 const testerPatchMail = {
   email: "bob.alice@example.com",
@@ -112,7 +80,10 @@ describe("Route PATCH users-me", () => {
         name: "Username Tetris",
         type: "text",
       });
-      await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
+      await cufData.insertCufData({
+        value: "CiccioGamer89.",
+        candidate: 0,
+      });
       //insert cuf_select
       await cuf.insertCuf({
         id: 2,
@@ -123,10 +94,12 @@ describe("Route PATCH users-me", () => {
         "wp_appq_custom_user_field_extras",
         cufSelectOption1
       );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_data",
-        cufSelectTesterOption1
-      );
+      await cufData.insertCufData({
+        id: 2,
+        value: "1",
+        custom_user_field_id: 2,
+        candidate: 0,
+      });
       //insert cuf_multiselect
       await cuf.insertCuf({
         id: 3,
@@ -141,14 +114,18 @@ describe("Route PATCH users-me", () => {
         "wp_appq_custom_user_field_extras",
         cufMultiSelectVal2
       );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_data",
-        cufMultiSelectTesterVal1
-      );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_data",
-        cufMultiSelectTesterVal2
-      );
+      await cufData.insertCufData({
+        id: 3,
+        value: "2",
+        custom_user_field_id: 3,
+        candidate: 0,
+      });
+      await cufData.insertCufData({
+        id: 4,
+        value: "3",
+        custom_user_field_id: 3,
+        candidate: 0,
+      });
 
       resolve(null);
     });
@@ -236,7 +213,10 @@ describe("Route PATCH users-me new mail", () => {
         name: "Username Tetris",
         type: "text",
       });
-      await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
+      await cufData.insertCufData({
+        value: "CiccioGamer89.",
+        candidate: 0,
+      });
       //insert cuf_select
       await cuf.insertCuf({
         id: 2,
@@ -247,10 +227,12 @@ describe("Route PATCH users-me new mail", () => {
         "wp_appq_custom_user_field_extras",
         cufSelectOption1
       );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_data",
-        cufSelectTesterOption1
-      );
+      await cufData.insertCufData({
+        id: 2,
+        value: "1",
+        custom_user_field_id: 2,
+        candidate: 0,
+      });
       //insert cuf_multiselect
       await cuf.insertCuf({
         id: 3,
@@ -265,14 +247,18 @@ describe("Route PATCH users-me new mail", () => {
         "wp_appq_custom_user_field_extras",
         cufMultiSelectVal2
       );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_data",
-        cufMultiSelectTesterVal1
-      );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_data",
-        cufMultiSelectTesterVal2
-      );
+      await cufData.insertCufData({
+        id: 3,
+        value: "2",
+        custom_user_field_id: 3,
+        candidate: 0,
+      });
+      await cufData.insertCufData({
+        id: 4,
+        value: "3",
+        custom_user_field_id: 3,
+        candidate: 0,
+      });
 
       resolve(null);
     });

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,11 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const testerFullLang1 = {
-  id: 1,
-  profile_id: 1,
-  language_id: 1,
-};
 const cufText = {
   //cuf
   id: 1,
@@ -127,8 +122,7 @@ describe("Route PATCH users-me", () => {
       await employmentsList.employment1({ display_name: "UNGUESS Tester" });
       await educationsList.education1({ display_name: "Phd" });
       await languagesList.lenguage1({ display_name: "Sicilian" });
-
-      await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
+      await testerLanguages.assignLanguage();
       //insert cuf_text
       await sqlite3.insert("wp_appq_custom_user_field", cufText);
       await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
@@ -241,7 +235,7 @@ describe("Route PATCH users-me new mail", () => {
       await employmentsList.employment1({ display_name: "UNGUESS Tester" });
       await educationsList.education1({ display_name: "Phd" });
       await languagesList.lenguage1({ display_name: "Sicilian" });
-      await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
+      await testerLanguages.assignLanguage();
       //insert cuf_text
       await sqlite3.insert("wp_appq_custom_user_field", cufText);
       await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,14 +21,10 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const lang1 = {
-  id: 1,
-  display_name: "Italian",
-};
 const testerFullLang1 = {
   id: 1,
   profile_id: 1,
-  language_id: lang1.id,
+  language_id: 1,
 };
 const cufText = {
   //cuf
@@ -130,8 +126,8 @@ describe("Route PATCH users-me", () => {
       });
       await employmentsList.employment1({ display_name: "UNGUESS Tester" });
       await educationsList.education1({ display_name: "Phd" });
+      await languagesList.lenguage1({ display_name: "Sicilian" });
 
-      await sqlite3.insert("wp_appq_lang", lang1);
       await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
       //insert cuf_text
       await sqlite3.insert("wp_appq_custom_user_field", cufText);
@@ -244,7 +240,7 @@ describe("Route PATCH users-me new mail", () => {
       });
       await employmentsList.employment1({ display_name: "UNGUESS Tester" });
       await educationsList.education1({ display_name: "Phd" });
-      await sqlite3.insert("wp_appq_lang", lang1);
+      await languagesList.lenguage1({ display_name: "Sicilian" });
       await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
       //insert cuf_text
       await sqlite3.insert("wp_appq_custom_user_field", cufText);

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,21 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const wpTester1 = {
-  ID: 1,
-  user_login: "bob_alice",
-  user_email: "bob.alice@example.com",
-};
-const wpTester2 = {
-  ID: 2,
-  user_login: "bob",
-  user_email: "bob@example.com",
-};
-const bug1 = {
-  id: 1,
-  wp_user_id: 1,
-  status_id: 2,
-};
 const testerCandidacy = {
   user_id: 1,
   accepted: 1,
@@ -162,8 +147,7 @@ describe("Route PATCH users-me", () => {
         employment_id: 1,
         education_id: 1,
       });
-      //await bugs.bug1();
-      await sqlite3.insert("wp_appq_evd_bug", bug1);
+      await bugs.basicBug({ status_id: 2 });
       await sqlite3.insert("wp_crowd_appq_has_candidate", testerCandidacy);
       await sqlite3.insert("wp_appq_certifications_list", certification1);
       await sqlite3.insert(
@@ -277,7 +261,7 @@ describe("Route PATCH users-me new mail", () => {
         education_id: 1,
         is_verified: 1,
       });
-      await sqlite3.insert("wp_appq_evd_bug", bug1);
+      await bugs.basicBug({ status_id: 2 });
       await sqlite3.insert("wp_crowd_appq_has_candidate", testerCandidacy);
       await sqlite3.insert("wp_appq_certifications_list", certification1);
       await sqlite3.insert(

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,10 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const testerPatchMail = {
-  email: "bob.alice@example.com",
-};
-
 describe("Route PATCH users-me", () => {
   beforeAll(async () => {
     return new Promise(async (resolve) => {
@@ -150,7 +146,7 @@ describe("Route PATCH users-me", () => {
   });
 });
 
-describe("Route PATCH users-me new mail", () => {
+describe("Route PATCH users-me accepted fields", () => {
   beforeEach(async () => {
     return new Promise(async (resolve) => {
       await attributions.validAttribution();
@@ -261,20 +257,19 @@ describe("Route PATCH users-me new mail", () => {
       resolve(null);
     });
   });
-  it("Should return 412 if email already exists", async () => {
+  it("Should return 412 if EMAIL already exists for another user", async () => {
     const response = await request(app)
       .patch(`/users/me`)
       .set("Authorization", `Bearer tester`)
       .send({ email: "bob@example.com" });
     expect(response.status).toBe(412);
   });
-  it("Should return tryber with new mail if send a new mail ", async () => {
+  it("Should return tryber with new EMAIL if send a new vaild EMAIL ", async () => {
     const responseGet1 = await request(app)
       .get(`/users/me`)
       .set("Authorization", `Bearer tester`);
     expect(responseGet1.status).toBe(200);
     expect(responseGet1.body.email).toBe("tester@example.com");
-    expect(responseGet1.body.is_verified).toBe(true);
 
     const responsePatch = await request(app)
       .patch(`/users/me`)
@@ -286,10 +281,158 @@ describe("Route PATCH users-me new mail", () => {
       .set("Authorization", `Bearer tester`);
     expect(responseGet2.status).toBe(200);
     expect(responseGet2.body.email).toBe("pino@example.com");
-    expect(responseGet2.body.is_verified).toBe(false);
     const wpTesterEmail = await sqlite3.get(
       "SELECT user_email FROM wp_users WHERE ID=1"
     );
+    expect(responsePatch.body.email).toBe("pino@example.com");
     expect(responsePatch.body.email).toBe(wpTesterEmail.user_email);
   });
+  it("Should return IS_VERIFIED false if before it was true and send a valid new mail", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.status).toBe(200);
+    expect(responseGet1.body.is_verified).toBe(true);
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ email: "pino@example.com" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=is_verified`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responseGet2.body.is_verified).toBe(false);
+  });
+
+  it("Should return tryber with new NAME if send a new NAME", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=name`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.name).toBe("tester");
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ name: "new-name" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=name`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.name).toBe("new-name");
+  });
+  it("Should return tryber with new SURNAME if send a new SURNAME", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=surname`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.surname).toBe("tester");
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ surname: "new-surname" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=name`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.surname).toBe("new-surname");
+  });
+  it("Should return tryber with new BIRTHDATE if send a new BIRTHDATE", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=birthDate`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.birthDate).toBe("1996-03-21");
+
+    const newBirthDate = new Date()
+      .toISOString()
+      .split(".")[0]
+      .replace("T", " ")
+      .substring(0, 10);
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ birthDate: newBirthDate });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=birthDate`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.birthDate).toBe(newBirthDate);
+  });
+  it("Should return tryber with new PHONE number if send a new PHONE number", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=phone`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.phone).toBe("+39696969696969");
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ phone: "0000-1234567890" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=phone`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.phone).toBe("0000-1234567890");
+  });
+
+  it("Should return tryber with new GENDER if send a new GENDER", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=gender`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.gender).toBe("male");
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ gender: "female" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=gender`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.gender).toBe("female");
+  });
+
+  it("Should return tryber with new CITY if send a new CITY", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=city`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.city).toBe("Rome");
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ city: "Ummary" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=city`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.city).toBe("Ummary");
+  });
+
+  it("Should return tryber with new COUNTRY if send a new COUNTRY", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=country`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.country).toBe("Italy");
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ country: "Custonacy Freedomland" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=country`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.country).toBe("Custonacy Freedomland");
+  });
+
+  //TODO: remain (accepted fields) to tests: onboarding_completed, profession, education and password
 });

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -1,0 +1,377 @@
+import { data as attributions } from "@src/__mocks__/mockedDb/attributions";
+import { data as bugs } from "@src/__mocks__/mockedDb/bug";
+import { data as certificationsList } from "@src/__mocks__/mockedDb/certificationList";
+import { data as campaignsCandidatures } from "@src/__mocks__/mockedDb/cp_has_candidates";
+import { data as cuf } from "@src/__mocks__/mockedDb/customUserFields";
+import { data as cufData } from "@src/__mocks__/mockedDb/customUserFieldsData";
+import { data as cufExtras } from "@src/__mocks__/mockedDb/customUserFieldsExtra";
+import { data as educationsList } from "@src/__mocks__/mockedDb/educationList";
+import { data as employmentsList } from "@src/__mocks__/mockedDb/employmentList";
+import { data as languagesList } from "@src/__mocks__/mockedDb/languageList";
+import { data as profileData } from "@src/__mocks__/mockedDb/profile";
+import { data as testerCertifications } from "@src/__mocks__/mockedDb/testerCertification";
+import { data as testerLanguages } from "@src/__mocks__/mockedDb/testerLanguage";
+import { data as wpOptions } from "@src/__mocks__/mockedDb/wp_options";
+import { data as wpUsers } from "@src/__mocks__/mockedDb/wp_users";
+import app from "@src/app";
+import sqlite3 from "@src/features/sqlite";
+import request from "supertest";
+
+jest.mock("@src/features/db");
+jest.mock("@appquality/wp-auth");
+jest.mock("@src/routes/users/me/_get/getRankData");
+
+const wpTester1 = {
+  ID: 1,
+  user_login: "bob_alice",
+  user_email: "bob.alice@example.com",
+};
+const wpTester2 = {
+  ID: 2,
+  user_login: "bob",
+  user_email: "bob@example.com",
+};
+const bug1 = {
+  id: 1,
+  wp_user_id: 1,
+  status_id: 2,
+};
+const testerCandidacy = {
+  user_id: 1,
+  accepted: 1,
+  results: 2,
+};
+const certification1 = {
+  id: 1,
+  name: "Best Tryber Ever",
+  area: "Testing 360",
+  institute: "Tryber",
+};
+const testerFullCertification1 = {
+  id: 1,
+  tester_id: 1,
+  cert_id: certification1.id,
+  achievement_date: new Date("01/01/2021").toISOString(),
+};
+const employment1 = {
+  id: 1,
+  display_name: "UNGUESS Tester",
+};
+const education1 = {
+  id: 1,
+  display_name: "Phd",
+};
+const lang1 = {
+  id: 1,
+  display_name: "Italian",
+};
+const testerFullLang1 = {
+  id: 1,
+  profile_id: 1,
+  language_id: lang1.id,
+};
+const cufText = {
+  //cuf
+  id: 1,
+  name: "Username Tetris",
+  type: "text",
+  enabled: 1,
+};
+const cufTextVal = {
+  //cuf_data
+  id: 1,
+  value: "CiccioGamer89.",
+  custom_user_field_id: 1,
+  profile_id: 1,
+  candidate: 0,
+};
+const cufSelect = {
+  //cuf
+  id: 2,
+  name: "Tipologia di spezie preferita",
+  type: "select",
+  enabled: 1,
+};
+const cufSelectOption1 = {
+  //cuf_exstras
+  id: 1,
+  name: "Habanero Scorpion",
+};
+const cufSelectTesterOption1 = {
+  //cuf_data
+  id: 2,
+  value: cufSelectOption1.id,
+  custom_user_field_id: cufSelect.id,
+  profile_id: 1,
+  candidate: 0,
+};
+const cufMultiselect = {
+  //cuf
+  id: 3,
+  name: "Fornitore di cardamomo preferito",
+  type: "multiselect",
+  enabled: 1,
+};
+const cufMultiSelectVal1 = {
+  //cuf_exstras
+  id: 2,
+  name: "Il cardamomo Siciliano",
+};
+const cufMultiSelectVal2 = {
+  //cuf_exstras
+  id: 3,
+  name: "Treviso, città del Cardamomo",
+};
+const cufMultiSelectTesterVal1 = {
+  //cuf_data
+  id: 3,
+  value: cufMultiSelectVal1.id,
+  custom_user_field_id: cufMultiselect.id,
+  profile_id: 1,
+  candidate: 0,
+};
+const cufMultiSelectTesterVal2 = {
+  //cuf_data
+  id: 4,
+  value: cufMultiSelectVal2.id,
+  custom_user_field_id: cufMultiselect.id,
+  profile_id: 1,
+  candidate: 0,
+};
+const testerPatchMail = {
+  email: "bob.alice@example.com",
+};
+
+describe("Route PATCH users-me", () => {
+  beforeAll(async () => {
+    return new Promise(async (resolve) => {
+      await wpUsers.basicUser({
+        user_login: "bob_alice",
+        user_email: "bob.alice@example.com",
+      });
+      await attributions.validAttribution();
+      await wpOptions.crowdWpOptions();
+      await profileData.basicTester({
+        booty: 69,
+        birth_date: "1996-03-21 00:00:00",
+        phone_number: "+39696969696969",
+        sex: 1,
+        country: "Italy",
+        city: "Rome",
+        onboarding_complete: 1,
+        employment_id: 1,
+        education_id: 1,
+      });
+      //await bugs.bug1();
+      await sqlite3.insert("wp_appq_evd_bug", bug1);
+      await sqlite3.insert("wp_crowd_appq_has_candidate", testerCandidacy);
+      await sqlite3.insert("wp_appq_certifications_list", certification1);
+      await sqlite3.insert(
+        "wp_appq_profile_certifications",
+        testerFullCertification1
+      );
+      await sqlite3.insert("wp_appq_employment", employment1);
+      await sqlite3.insert("wp_appq_education", education1);
+      await sqlite3.insert("wp_appq_lang", lang1);
+      await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
+      //insert cuf_text
+      await sqlite3.insert("wp_appq_custom_user_field", cufText);
+      await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
+      //insert cuf_select
+      await sqlite3.insert("wp_appq_custom_user_field", cufSelect);
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_extras",
+        cufSelectOption1
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_data",
+        cufSelectTesterOption1
+      );
+      //insert cuf_multiselect
+      await sqlite3.insert("wp_appq_custom_user_field", cufMultiselect);
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_extras",
+        cufMultiSelectVal1
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_extras",
+        cufMultiSelectVal2
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_data",
+        cufMultiSelectTesterVal1
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_data",
+        cufMultiSelectTesterVal2
+      );
+
+      resolve(null);
+    });
+  });
+  afterAll(async () => {
+    return new Promise(async (resolve) => {
+      await wpUsers.drop();
+      await attributions.drop();
+      await wpOptions.drop();
+      await profileData.drop();
+      await bugs.drop();
+      await campaignsCandidatures.drop();
+      await certificationsList.drop();
+      await testerCertifications.drop();
+      await employmentsList.drop();
+      await educationsList.drop();
+      await languagesList.drop();
+      await testerLanguages.drop();
+      await cuf.drop();
+      await cufData.drop();
+      await cufExtras.drop();
+      resolve(null);
+    });
+  });
+  it("Should not update user when no parameters were given", async () => {
+    const responseGetBeforePatch = await request(app)
+      .get(`/users/me?fields=all`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGetBeforePatch.status).toBe(200);
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`);
+    expect(responsePatch.status).toBe(200);
+
+    const responseGetAfterPatch = await request(app)
+      .get(`/users/me?fields=all`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGetAfterPatch.status).toBe(200);
+    expect(responseGetAfterPatch.body).toMatchObject(
+      responseGetBeforePatch.body
+    );
+  });
+});
+
+describe("Route PATCH users-me new mail", () => {
+  beforeEach(async () => {
+    return new Promise(async (resolve) => {
+      await attributions.validAttribution();
+
+      await wpUsers.basicUser({
+        user_login: "bob_alice",
+        user_email: "bob.alice@example.com",
+      });
+      await wpUsers.basicUser({
+        ID: 2,
+        user_login: "bob",
+        user_email: "bob@example.com",
+      });
+      wpOptions.crowdWpOptions();
+      await profileData.basicTester({
+        booty: 69,
+        birth_date: "1996-03-21 00:00:00",
+        phone_number: "+39696969696969",
+        sex: 1,
+        country: "Italy",
+        city: "Rome",
+        onboarding_complete: 1,
+        employment_id: 1,
+        education_id: 1,
+        is_verified: 1,
+      });
+      await sqlite3.insert("wp_appq_evd_bug", bug1);
+      await sqlite3.insert("wp_crowd_appq_has_candidate", testerCandidacy);
+      await sqlite3.insert("wp_appq_certifications_list", certification1);
+      await sqlite3.insert(
+        "wp_appq_profile_certifications",
+        testerFullCertification1
+      );
+      await sqlite3.insert("wp_appq_employment", employment1);
+      await sqlite3.insert("wp_appq_education", education1);
+      await sqlite3.insert("wp_appq_lang", lang1);
+      await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
+      //insert cuf_text
+      await sqlite3.insert("wp_appq_custom_user_field", cufText);
+      await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
+      //insert cuf_select
+      await sqlite3.insert("wp_appq_custom_user_field", cufSelect);
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_extras",
+        cufSelectOption1
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_data",
+        cufSelectTesterOption1
+      );
+      //insert cuf_multiselect
+      await sqlite3.insert("wp_appq_custom_user_field", cufMultiselect);
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_extras",
+        cufMultiSelectVal1
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_extras",
+        cufMultiSelectVal2
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_data",
+        cufMultiSelectTesterVal1
+      );
+      await sqlite3.insert(
+        "wp_appq_custom_user_field_data",
+        cufMultiSelectTesterVal2
+      );
+
+      resolve(null);
+    });
+  });
+  afterEach(async () => {
+    return new Promise(async (resolve) => {
+      await wpUsers.drop();
+      await attributions.drop();
+      await wpOptions.drop();
+      await profileData.drop();
+      await bugs.drop();
+      await campaignsCandidatures.drop();
+      await certificationsList.drop();
+      await testerCertifications.drop();
+      await employmentsList.drop();
+      await educationsList.drop();
+      await languagesList.drop();
+      await testerLanguages.drop();
+      await cuf.drop();
+      await cufData.drop();
+      await cufExtras.drop();
+      resolve(null);
+    });
+  });
+  it("Should return 412 if email already exists", async () => {
+    const response = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ email: "bob@example.com" });
+    expect(response.status).toBe(412);
+  });
+  it("Should return tryber with new mail if send a new mail ", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.status).toBe(200);
+    expect(responseGet1.body.email).toBe("tester@example.com");
+    expect(responseGet1.body.is_verified).toBe(true);
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ email: "pino@example.com" });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=email,is_verified`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responseGet2.body.email).toBe("pino@example.com");
+    expect(responseGet2.body.is_verified).toBe(false);
+    const wpTesterEmail = await sqlite3.get(
+      "SELECT user_email FROM wp_users WHERE ID=1"
+    );
+    expect(responsePatch.body.email).toBe(wpTesterEmail.user_email);
+  });
+});

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,13 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const cufText = {
-  //cuf
-  id: 1,
-  name: "Username Tetris",
-  type: "text",
-  enabled: 1,
-};
 const cufTextVal = {
   //cuf_data
   id: 1,
@@ -35,13 +28,6 @@ const cufTextVal = {
   custom_user_field_id: 1,
   profile_id: 1,
   candidate: 0,
-};
-const cufSelect = {
-  //cuf
-  id: 2,
-  name: "Tipologia di spezie preferita",
-  type: "select",
-  enabled: 1,
 };
 const cufSelectOption1 = {
   //cuf_exstras
@@ -52,16 +38,14 @@ const cufSelectTesterOption1 = {
   //cuf_data
   id: 2,
   value: cufSelectOption1.id,
-  custom_user_field_id: cufSelect.id,
+  custom_user_field_id: 2,
   profile_id: 1,
   candidate: 0,
 };
 const cufMultiselect = {
-  //cuf
   id: 3,
   name: "Fornitore di cardamomo preferito",
   type: "multiselect",
-  enabled: 1,
 };
 const cufMultiSelectVal1 = {
   //cuf_exstras
@@ -77,7 +61,7 @@ const cufMultiSelectTesterVal1 = {
   //cuf_data
   id: 3,
   value: cufMultiSelectVal1.id,
-  custom_user_field_id: cufMultiselect.id,
+  custom_user_field_id: 3,
   profile_id: 1,
   candidate: 0,
 };
@@ -85,7 +69,7 @@ const cufMultiSelectTesterVal2 = {
   //cuf_data
   id: 4,
   value: cufMultiSelectVal2.id,
-  custom_user_field_id: cufMultiselect.id,
+  custom_user_field_id: 3,
   profile_id: 1,
   candidate: 0,
 };
@@ -124,10 +108,17 @@ describe("Route PATCH users-me", () => {
       await languagesList.lenguage1({ display_name: "Sicilian" });
       await testerLanguages.assignLanguage();
       //insert cuf_text
-      await sqlite3.insert("wp_appq_custom_user_field", cufText);
+      await cuf.insertCuf({
+        name: "Username Tetris",
+        type: "text",
+      });
       await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
       //insert cuf_select
-      await sqlite3.insert("wp_appq_custom_user_field", cufSelect);
+      await cuf.insertCuf({
+        id: 2,
+        name: "Tipologia di spezie preferita",
+        type: "select",
+      });
       await sqlite3.insert(
         "wp_appq_custom_user_field_extras",
         cufSelectOption1
@@ -137,7 +128,11 @@ describe("Route PATCH users-me", () => {
         cufSelectTesterOption1
       );
       //insert cuf_multiselect
-      await sqlite3.insert("wp_appq_custom_user_field", cufMultiselect);
+      await cuf.insertCuf({
+        id: 3,
+        name: "Fornitore di cardamomo preferito",
+        type: "multiselect",
+      });
       await sqlite3.insert(
         "wp_appq_custom_user_field_extras",
         cufMultiSelectVal1
@@ -237,10 +232,17 @@ describe("Route PATCH users-me new mail", () => {
       await languagesList.lenguage1({ display_name: "Sicilian" });
       await testerLanguages.assignLanguage();
       //insert cuf_text
-      await sqlite3.insert("wp_appq_custom_user_field", cufText);
+      await cuf.insertCuf({
+        name: "Username Tetris",
+        type: "text",
+      });
       await sqlite3.insert("wp_appq_custom_user_field_data", cufTextVal);
       //insert cuf_select
-      await sqlite3.insert("wp_appq_custom_user_field", cufSelect);
+      await cuf.insertCuf({
+        id: 2,
+        name: "Tipologia di spezie preferita",
+        type: "select",
+      });
       await sqlite3.insert(
         "wp_appq_custom_user_field_extras",
         cufSelectOption1
@@ -250,7 +252,11 @@ describe("Route PATCH users-me new mail", () => {
         cufSelectTesterOption1
       );
       //insert cuf_multiselect
-      await sqlite3.insert("wp_appq_custom_user_field", cufMultiselect);
+      await cuf.insertCuf({
+        id: 3,
+        name: "Fornitore di cardamomo preferito",
+        type: "multiselect",
+      });
       await sqlite3.insert(
         "wp_appq_custom_user_field_extras",
         cufMultiSelectVal1

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,16 +21,10 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const certification1 = {
-  id: 1,
-  name: "Best Tryber Ever",
-  area: "Testing 360",
-  institute: "Tryber",
-};
 const testerFullCertification1 = {
   id: 1,
   tester_id: 1,
-  cert_id: certification1.id,
+  cert_id: 1,
   achievement_date: new Date("01/01/2021").toISOString(),
 };
 const employment1 = {
@@ -144,7 +138,8 @@ describe("Route PATCH users-me", () => {
       });
       await bugs.basicBug({ status_id: 2 });
       await campaignsCandidatures.candidate1({ accepted: 1, results: 2 });
-      await sqlite3.insert("wp_appq_certifications_list", certification1);
+      await certificationsList.certification1();
+
       await sqlite3.insert(
         "wp_appq_profile_certifications",
         testerFullCertification1
@@ -258,7 +253,7 @@ describe("Route PATCH users-me new mail", () => {
       });
       await bugs.basicBug({ status_id: 2 });
       await campaignsCandidatures.candidate1({ accepted: 1, results: 2 });
-      await sqlite3.insert("wp_appq_certifications_list", certification1);
+      await certificationsList.certification1();
       await sqlite3.insert(
         "wp_appq_profile_certifications",
         testerFullCertification1

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,11 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const testerCandidacy = {
-  user_id: 1,
-  accepted: 1,
-  results: 2,
-};
 const certification1 = {
   id: 1,
   name: "Best Tryber Ever",
@@ -148,7 +143,7 @@ describe("Route PATCH users-me", () => {
         education_id: 1,
       });
       await bugs.basicBug({ status_id: 2 });
-      await sqlite3.insert("wp_crowd_appq_has_candidate", testerCandidacy);
+      await campaignsCandidatures.candidate1({ accepted: 1, results: 2 });
       await sqlite3.insert("wp_appq_certifications_list", certification1);
       await sqlite3.insert(
         "wp_appq_profile_certifications",
@@ -262,7 +257,7 @@ describe("Route PATCH users-me new mail", () => {
         is_verified: 1,
       });
       await bugs.basicBug({ status_id: 2 });
-      await sqlite3.insert("wp_crowd_appq_has_candidate", testerCandidacy);
+      await campaignsCandidatures.candidate1({ accepted: 1, results: 2 });
       await sqlite3.insert("wp_appq_certifications_list", certification1);
       await sqlite3.insert(
         "wp_appq_profile_certifications",

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,12 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const testerFullCertification1 = {
-  id: 1,
-  tester_id: 1,
-  cert_id: 1,
-  achievement_date: new Date("01/01/2021").toISOString(),
-};
 const employment1 = {
   id: 1,
   display_name: "UNGUESS Tester",
@@ -139,11 +133,10 @@ describe("Route PATCH users-me", () => {
       await bugs.basicBug({ status_id: 2 });
       await campaignsCandidatures.candidate1({ accepted: 1, results: 2 });
       await certificationsList.certification1();
+      await testerCertifications.assignCertification({
+        achievement_date: new Date("01/01/2021").toISOString(),
+      });
 
-      await sqlite3.insert(
-        "wp_appq_profile_certifications",
-        testerFullCertification1
-      );
       await sqlite3.insert("wp_appq_employment", employment1);
       await sqlite3.insert("wp_appq_education", education1);
       await sqlite3.insert("wp_appq_lang", lang1);
@@ -254,10 +247,9 @@ describe("Route PATCH users-me new mail", () => {
       await bugs.basicBug({ status_id: 2 });
       await campaignsCandidatures.candidate1({ accepted: 1, results: 2 });
       await certificationsList.certification1();
-      await sqlite3.insert(
-        "wp_appq_profile_certifications",
-        testerFullCertification1
-      );
+      await testerCertifications.assignCertification({
+        achievement_date: new Date("01/01/2021").toISOString(),
+      });
       await sqlite3.insert("wp_appq_employment", employment1);
       await sqlite3.insert("wp_appq_education", education1);
       await sqlite3.insert("wp_appq_lang", lang1);

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -180,7 +180,12 @@ describe("Route PATCH users-me accepted fields", () => {
         achievement_date: new Date("01/01/2021").toISOString(),
       });
       await employmentsList.employment1({ display_name: "UNGUESS Tester" });
+      await employmentsList.employment1({
+        id: 2,
+        display_name: "Best Tester in the world",
+      });
       await educationsList.education1({ display_name: "Phd" });
+      await educationsList.education1({ id: 2, display_name: "Phd Professor" });
       await languagesList.lenguage1({ display_name: "Sicilian" });
       await testerLanguages.assignLanguage();
       //insert cuf_text
@@ -433,6 +438,49 @@ describe("Route PATCH users-me accepted fields", () => {
     expect(responseGet2.status).toBe(200);
     expect(responsePatch.body.country).toBe("Custonacy Freedomland");
   });
+  it("Should return tryber with new PROFESSION if send a new PROFESSION", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=profession`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.profession).toStrictEqual({
+      id: 1,
+      name: "UNGUESS Tester",
+    });
 
-  //TODO: remain (accepted fields) to tests: onboarding_completed, profession, education and password
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ profession: 2 });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=profession`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.profession).toStrictEqual({
+      id: 2,
+      name: "Best Tester in the world",
+    });
+  });
+  it("Should return tryber with new EDUCATION if send a new EDUCATION", async () => {
+    const responseGet1 = await request(app)
+      .get(`/users/me?fields=education`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet1.body.education).toStrictEqual({ id: 1, name: "Phd" });
+
+    const responsePatch = await request(app)
+      .patch(`/users/me`)
+      .set("Authorization", `Bearer tester`)
+      .send({ education: 2 });
+
+    const responseGet2 = await request(app)
+      .get(`/users/me?fields=education`)
+      .set("Authorization", `Bearer tester`);
+    expect(responseGet2.status).toBe(200);
+    expect(responsePatch.body.education).toStrictEqual({
+      id: 2,
+      name: "Phd Professor",
+    });
+  });
+
+  //TODO: remain (accepted fields) to tests: and password
 });

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,26 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const cufSelectOption1 = {
-  //cuf_exstras
-  id: 1,
-  name: "Habanero Scorpion",
-};
-const cufMultiselect = {
-  id: 3,
-  name: "Fornitore di cardamomo preferito",
-  type: "multiselect",
-};
-const cufMultiSelectVal1 = {
-  //cuf_exstras
-  id: 2,
-  name: "Il cardamomo Siciliano",
-};
-const cufMultiSelectVal2 = {
-  //cuf_exstras
-  id: 3,
-  name: "Treviso, città del Cardamomo",
-};
 const testerPatchMail = {
   email: "bob.alice@example.com",
 };
@@ -90,10 +70,9 @@ describe("Route PATCH users-me", () => {
         name: "Tipologia di spezie preferita",
         type: "select",
       });
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_extras",
-        cufSelectOption1
-      );
+      await cufExtras.insertCufExtras({
+        name: "Habanero Scorpion",
+      });
       await cufData.insertCufData({
         id: 2,
         value: "1",
@@ -106,14 +85,14 @@ describe("Route PATCH users-me", () => {
         name: "Fornitore di cardamomo preferito",
         type: "multiselect",
       });
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_extras",
-        cufMultiSelectVal1
-      );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_extras",
-        cufMultiSelectVal2
-      );
+      await cufExtras.insertCufExtras({
+        id: 2,
+        name: "Il cardamomo Siciliano",
+      });
+      await cufExtras.insertCufExtras({
+        id: 3,
+        name: "Treviso, città del Cardamomo",
+      });
       await cufData.insertCufData({
         id: 3,
         value: "2",
@@ -223,10 +202,9 @@ describe("Route PATCH users-me new mail", () => {
         name: "Tipologia di spezie preferita",
         type: "select",
       });
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_extras",
-        cufSelectOption1
-      );
+      await cufExtras.insertCufExtras({
+        name: "Habanero Scorpion",
+      });
       await cufData.insertCufData({
         id: 2,
         value: "1",
@@ -239,14 +217,14 @@ describe("Route PATCH users-me new mail", () => {
         name: "Fornitore di cardamomo preferito",
         type: "multiselect",
       });
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_extras",
-        cufMultiSelectVal1
-      );
-      await sqlite3.insert(
-        "wp_appq_custom_user_field_extras",
-        cufMultiSelectVal2
-      );
+      await cufExtras.insertCufExtras({
+        id: 2,
+        name: "Il cardamomo Siciliano",
+      });
+      await cufExtras.insertCufExtras({
+        id: 3,
+        name: "Treviso, città del Cardamomo",
+      });
       await cufData.insertCufData({
         id: 3,
         value: "2",

--- a/src/routes/users/me/_patch/index.spec.ts
+++ b/src/routes/users/me/_patch/index.spec.ts
@@ -21,14 +21,6 @@ jest.mock("@src/features/db");
 jest.mock("@appquality/wp-auth");
 jest.mock("@src/routes/users/me/_get/getRankData");
 
-const employment1 = {
-  id: 1,
-  display_name: "UNGUESS Tester",
-};
-const education1 = {
-  id: 1,
-  display_name: "Phd",
-};
 const lang1 = {
   id: 1,
   display_name: "Italian",
@@ -136,9 +128,9 @@ describe("Route PATCH users-me", () => {
       await testerCertifications.assignCertification({
         achievement_date: new Date("01/01/2021").toISOString(),
       });
+      await employmentsList.employment1({ display_name: "UNGUESS Tester" });
+      await educationsList.education1({ display_name: "Phd" });
 
-      await sqlite3.insert("wp_appq_employment", employment1);
-      await sqlite3.insert("wp_appq_education", education1);
       await sqlite3.insert("wp_appq_lang", lang1);
       await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
       //insert cuf_text
@@ -250,8 +242,8 @@ describe("Route PATCH users-me new mail", () => {
       await testerCertifications.assignCertification({
         achievement_date: new Date("01/01/2021").toISOString(),
       });
-      await sqlite3.insert("wp_appq_employment", employment1);
-      await sqlite3.insert("wp_appq_education", education1);
+      await employmentsList.employment1({ display_name: "UNGUESS Tester" });
+      await educationsList.education1({ display_name: "Phd" });
       await sqlite3.insert("wp_appq_lang", lang1);
       await sqlite3.insert("wp_appq_profile_has_lang", testerFullLang1);
       //insert cuf_text


### PR DESCRIPTION
After refactoring of mocks, there were added the following tests to the  PATCH /users/me:
 -  Route PATCH users-me:
    - Should not update user when no parameters were given

- Route PATCH users-me accepted fields:
    - Should return 412 if EMAIL already exists for another user
    - Should return tryber with new EMAIL if send a new vaild EMAIL
    - Should return IS_VERIFIED false if before it was true and send a valid new mail
    - Should return tryber with new NAME if send a new NAME
    - Should return tryber with new SURNAME if send a new SURNAME
    - Should return tryber with new BIRTHDATE if send a new BIRTHDATE
    - Should return tryber with new PHONE number if send a new PHONE number
    - Should return tryber with new GENDER if send a new GENDER
    - Should return tryber with new CITY if send a new CITY
    - Should return tryber with new COUNTRY if send a new COUNTRY
    - Should return tryber with new PROFESSION if send a new PROFESSION
    - Should return tryber with new EDUCATION if send a new EDUCATION
    - Should return 417 if send wrong oldPassword
    - Should return an error if send a new password without old password
    - Should return 200 if send right oldPassword and a new password