### PR TITLE
CP-2181 candidate device=random or device={device_id}

### DIFF
--- a/src/features/class/Devices.ts
+++ b/src/features/class/Devices.ts
@@ -12,6 +12,7 @@ type DeviceType = {
   pc_type: string;
   source_id: number;
 };
+export type UserDevice = StoplightComponents["schemas"]["UserDevice"];
 
 class Devices {
   private baseQuery = `SELECT
@@ -30,7 +31,7 @@ class Devices {
   else 5
 end asc , os.name ASC`;
 
-  public async getOne(id: number) {
+  public async getOne(id: number): Promise<UserDevice | false> {
     const data = await db.query(
       db.format(`${this.baseQuery} AND d.id = ?`, [id])
     );
@@ -40,7 +41,7 @@ end asc , os.name ASC`;
     return this.format(data[0]);
   }
 
-  public async getMany(where: { testerId: number }) {
+  public async getMany(where: { testerId: number }): Promise<UserDevice[]> {
     const { query, data } = mapQuery();
     const results = await db.query(
       db.format(`${this.baseQuery} ${query} ${this.baseOrder}`, [...data])

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -642,6 +642,11 @@ paths:
                   type: number
               required:
                 - tester_id
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: device
   /popups:
     get:
       summary: Get all popups

--- a/src/routes/campaigns/campaignId/candidates/_post/createCandidature/index.ts
+++ b/src/routes/campaigns/campaignId/candidates/_post/createCandidature/index.ts
@@ -1,17 +1,21 @@
 import * as db from "@src/features/db";
 
-export default async (wpId: number, campaignId: number) => {
-  let candidatureCreation = await db.query(
+export default async (
+  wpId: number,
+  campaignId: number,
+  selectedDevice: number
+) => {
+  //create candidature
+  await db.query(
     db.format(
       `INSERT INTO wp_crowd_appq_has_candidate 
             (user_id, campaign_id, accepted, results, devices, selected_device, group_id)
           VALUES 
-            (?, ?, 1 , 0 , 0 , 0 , 1)`,
-      [wpId, campaignId]
+            (?, ?, 1 , 0 , 0 , ? , 1)`,
+      [wpId, campaignId, selectedDevice]
     )
   );
   let candidature = await db.query(
-    //get candidature
     db.format(
       `
         SELECT t.id as tester_id, 

--- a/src/routes/campaigns/campaignId/candidates/_post/index.spec.ts
+++ b/src/routes/campaigns/campaignId/candidates/_post/index.spec.ts
@@ -116,15 +116,15 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has no
       resolve(null);
     });
   });
-  it("Should candidate the user on success", async () => {
+  it("Should candidate the user on success with selected_device=0", async () => {
     const beforeCandidature = await sqlite3.get(`
       SELECT c.accepted,c.results FROM 
       wp_crowd_appq_has_candidate c
       JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
       WHERE t.id = 1 AND c.campaign_id = 1
     `);
-
     expect(beforeCandidature).toBe(undefined);
+
     await request(app)
       .post("/campaigns/1/candidates?device=random")
       .send({ tester_id: 1 })
@@ -136,14 +136,13 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has no
       JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
       WHERE t.id = 1 AND c.campaign_id = 1
     `);
-
     expect(afterCandidature).toEqual({
       accepted: 1,
       results: 0,
       selected_device: 0,
     });
   });
-  it("Should return the candidature on success", async () => {
+  it("Should return the candidature on success with device=any", async () => {
     const response = await request(app)
       .post("/campaigns/1/candidates?device=random")
       .send({ tester_id: 1 })
@@ -200,19 +199,15 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
       resolve(null);
     });
   });
-  it("Should candidate the user on success", async () => {
+  it("Should candidate the user on success with selected_device one of user devices", async () => {
     const beforeCandidature = await sqlite3.get(`
       SELECT c.accepted,c.results FROM 
       wp_crowd_appq_has_candidate c
       JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
       WHERE t.id = 1 AND c.campaign_id = 1
     `);
-
-    const testerDevices = await sqlite3.all(`
-    SELECT * FROM wp_crowd_appq_device WHERE id_profile = 1;
-  `);
-
     expect(beforeCandidature).toBe(undefined);
+
     await request(app)
       .post("/campaigns/1/candidates?device=random")
       .send({ tester_id: 1 })
@@ -224,7 +219,6 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
       JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
       WHERE t.id = 1 AND c.campaign_id = 1
     `);
-    console.log(afterCandidature);
     expect([
       {
         accepted: 1,
@@ -238,7 +232,7 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
       },
     ]).toContainEqual(afterCandidature);
   });
-  it("Should return the candidature on success with the first available device as the selected device", async () => {
+  it("Should return the candidature with random device from user device", async () => {
     const response = await request(app)
       .post("/campaigns/1/candidates?device=random")
       .send({ tester_id: 1 })

--- a/src/routes/campaigns/campaignId/candidates/_post/index.spec.ts
+++ b/src/routes/campaigns/campaignId/candidates/_post/index.spec.ts
@@ -211,7 +211,6 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
     const testerDevices = await sqlite3.all(`
     SELECT * FROM wp_crowd_appq_device WHERE id_profile = 1;
   `);
-    console.log("testerDevices2", testerDevices);
 
     expect(beforeCandidature).toBe(undefined);
     await request(app)
@@ -225,12 +224,19 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
       JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
       WHERE t.id = 1 AND c.campaign_id = 1
     `);
-
-    expect(afterCandidature).toEqual({
-      accepted: 1,
-      results: 0,
-      selected_device: 1,
-    });
+    console.log(afterCandidature);
+    expect([
+      {
+        accepted: 1,
+        results: 0,
+        selected_device: 1,
+      },
+      {
+        accepted: 1,
+        results: 0,
+        selected_device: 2,
+      },
+    ]).toContainEqual(afterCandidature);
   });
   it("Should return the candidature on success with the first available device as the selected device", async () => {
     const response = await request(app)
@@ -238,12 +244,8 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
       .send({ tester_id: 1 })
       .set("authorization", "Bearer admin");
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      tester_id: 1,
-      campaign_id: 1,
-      accepted: true,
-      status: "ready",
-      device: {
+    expect([
+      {
         id: 1,
         type: "PC",
         device: { pc_type: "Laptop" },
@@ -253,6 +255,16 @@ describe("POST /campaigns/{campaignId}/candidates?device=random when user has tw
           version: "Linux (1.0)",
         },
       },
-    });
+      {
+        id: 2,
+        type: "PC",
+        device: { pc_type: "Server" },
+        operating_system: {
+          id: 1,
+          platform: "Platform 1",
+          version: "Linux (1.0)",
+        },
+      },
+    ]).toContainEqual(response.body.device);
   });
 });

--- a/src/routes/campaigns/campaignId/candidates/_post/index.spec.ts
+++ b/src/routes/campaigns/campaignId/candidates/_post/index.spec.ts
@@ -4,22 +4,25 @@ import Campaigns from "@src/__mocks__/mockedDb/campaign";
 import Candidature from "@src/__mocks__/mockedDb/cpHasCandidates";
 import { data as testerData } from "@src/__mocks__/mockedDb/profile";
 import { data as wpUsersData } from "@src/__mocks__/mockedDb/wp_users";
+import DeviceOs from "@src/__mocks__/mockedDb/deviceOs";
+import DevicePlatform from "@src/__mocks__/mockedDb/devicePlatform";
+import TesterDevice from "@src/__mocks__/mockedDb/testerDevice";
 import request from "supertest";
 
 describe("POST /campaigns/{campaignId}/candidates", () => {
   beforeEach(async () => {
     return new Promise(async (resolve) => {
-      await Campaigns.insert();
       await testerData.testerWithBooty();
       await wpUsersData.basicUser();
+      await Campaigns.insert();
       resolve(null);
     });
   });
   afterEach(async () => {
     return new Promise(async (resolve) => {
-      await Campaigns.clear();
       await testerData.drop();
       await wpUsersData.drop();
+      await Campaigns.clear();
       await Candidature.clear();
       resolve(null);
     });
@@ -68,7 +71,7 @@ describe("POST /campaigns/{campaignId}/candidates", () => {
       .send({ tester_id: 1 })
       .set("authorization", "Bearer admin");
     const afterCandidature = await sqlite3.get(`
-      SELECT c.accepted,c.results FROM 
+      SELECT c.accepted,c.results, c.selected_device FROM 
       wp_crowd_appq_has_candidate c
       JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
       WHERE t.id = 1 AND c.campaign_id = 1
@@ -76,6 +79,7 @@ describe("POST /campaigns/{campaignId}/candidates", () => {
     expect(afterCandidature).toEqual({
       accepted: 1,
       results: 0,
+      selected_device: 0,
     });
   });
   it("Should return the candidature on success", async () => {
@@ -90,6 +94,165 @@ describe("POST /campaigns/{campaignId}/candidates", () => {
       accepted: true,
       status: "ready",
       device: "any",
+    });
+  });
+});
+
+describe("POST /campaigns/{campaignId}/candidates?device=random when user has not devices", () => {
+  beforeEach(async () => {
+    return new Promise(async (resolve) => {
+      await testerData.testerWithBooty();
+      await wpUsersData.basicUser();
+      await Campaigns.insert();
+      resolve(null);
+    });
+  });
+  afterEach(async () => {
+    return new Promise(async (resolve) => {
+      await testerData.drop();
+      await wpUsersData.drop();
+      await Campaigns.clear();
+      await Candidature.clear();
+      resolve(null);
+    });
+  });
+  it("Should candidate the user on success", async () => {
+    const beforeCandidature = await sqlite3.get(`
+      SELECT c.accepted,c.results FROM 
+      wp_crowd_appq_has_candidate c
+      JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
+      WHERE t.id = 1 AND c.campaign_id = 1
+    `);
+
+    expect(beforeCandidature).toBe(undefined);
+    await request(app)
+      .post("/campaigns/1/candidates?device=random")
+      .send({ tester_id: 1 })
+      .set("authorization", "Bearer admin");
+
+    const afterCandidature = await sqlite3.get(`
+      SELECT c.accepted,c.results, c.selected_device FROM 
+      wp_crowd_appq_has_candidate c
+      JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
+      WHERE t.id = 1 AND c.campaign_id = 1
+    `);
+
+    expect(afterCandidature).toEqual({
+      accepted: 1,
+      results: 0,
+      selected_device: 0,
+    });
+  });
+  it("Should return the candidature on success", async () => {
+    const response = await request(app)
+      .post("/campaigns/1/candidates?device=random")
+      .send({ tester_id: 1 })
+      .set("authorization", "Bearer admin");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      tester_id: 1,
+      campaign_id: 1,
+      accepted: true,
+      status: "ready",
+      device: "any",
+    });
+  });
+});
+
+describe("POST /campaigns/{campaignId}/candidates?device=random when user has two devices", () => {
+  beforeEach(async () => {
+    return new Promise(async (resolve) => {
+      await testerData.testerWithBooty();
+      await wpUsersData.basicUser();
+      await Campaigns.insert();
+      await DeviceOs.insert({ id: 1, display_name: "Linux" });
+      await DevicePlatform.insert({ id: 1, name: "Platform 1" });
+      await TesterDevice.insert({
+        id: 1,
+        id_profile: 1,
+        enabled: 1,
+        form_factor: "PC",
+        pc_type: "Laptop",
+        os_version_id: 1,
+        platform_id: 1,
+      });
+      await TesterDevice.insert({
+        id: 2,
+        id_profile: 1,
+        enabled: 1,
+        form_factor: "PC",
+        pc_type: "Server",
+        os_version_id: 1,
+        platform_id: 1,
+      });
+      resolve(null);
+    });
+  });
+  afterEach(async () => {
+    return new Promise(async (resolve) => {
+      await testerData.drop();
+      await wpUsersData.drop();
+      await Campaigns.clear();
+      await Candidature.clear();
+      await TesterDevice.clear();
+      await DeviceOs.clear();
+      await DevicePlatform.clear();
+      resolve(null);
+    });
+  });
+  it("Should candidate the user on success", async () => {
+    const beforeCandidature = await sqlite3.get(`
+      SELECT c.accepted,c.results FROM 
+      wp_crowd_appq_has_candidate c
+      JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
+      WHERE t.id = 1 AND c.campaign_id = 1
+    `);
+
+    const testerDevices = await sqlite3.all(`
+    SELECT * FROM wp_crowd_appq_device WHERE id_profile = 1;
+  `);
+    console.log("testerDevices2", testerDevices);
+
+    expect(beforeCandidature).toBe(undefined);
+    await request(app)
+      .post("/campaigns/1/candidates?device=random")
+      .send({ tester_id: 1 })
+      .set("authorization", "Bearer admin");
+
+    const afterCandidature = await sqlite3.get(`
+      SELECT c.accepted,c.results, c.selected_device FROM 
+      wp_crowd_appq_has_candidate c
+      JOIN wp_appq_evd_profile t ON (t.wp_user_id = c.user_id)
+      WHERE t.id = 1 AND c.campaign_id = 1
+    `);
+
+    expect(afterCandidature).toEqual({
+      accepted: 1,
+      results: 0,
+      selected_device: 1,
+    });
+  });
+  it("Should return the candidature on success with the first available device as the selected device", async () => {
+    const response = await request(app)
+      .post("/campaigns/1/candidates?device=random")
+      .send({ tester_id: 1 })
+      .set("authorization", "Bearer admin");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      tester_id: 1,
+      campaign_id: 1,
+      accepted: true,
+      status: "ready",
+      device: {
+        id: 1,
+        type: "PC",
+        device: { pc_type: "Laptop" },
+        operating_system: {
+          id: 1,
+          platform: "Platform 1",
+          version: "Linux (1.0)",
+        },
+      },
     });
   });
 });

--- a/src/routes/campaigns/campaignId/candidates/_post/index.ts
+++ b/src/routes/campaigns/campaignId/candidates/_post/index.ts
@@ -29,10 +29,10 @@ const testerShouldExist = async (testerId: number) => {
 const getSelectedDeviceId = async (
   testerId: number,
   params: StoplightOperations["post-campaigns-campaign-candidates"]["parameters"]["query"]
-) => {
+): Promise<number> => {
   const userDevices = await new Devices().getMany({ testerId });
   if (params.device?.toString() === "random" && userDevices.length) {
-    return userDevices[0].id;
+    return userDevices[Math.floor(Math.random() * userDevices.length)].id;
   }
   return 0;
 };

--- a/src/routes/campaigns/campaignId/candidates/_post/index.ts
+++ b/src/routes/campaigns/campaignId/candidates/_post/index.ts
@@ -1,3 +1,4 @@
+import Devices from "@src/features/class/Devices";
 import * as db from "@src/features/db";
 import debugMessage from "@src/features/debugMessage";
 import adminOnly from "@src/features/preconditions/adminOnly";
@@ -25,6 +26,16 @@ const testerShouldExist = async (testerId: number) => {
   return tester[0];
 };
 
+const getSelectedDeviceId = async (
+  testerId: number,
+  params: StoplightOperations["post-campaigns-campaign-candidates"]["parameters"]["query"]
+) => {
+  const userDevices = await new Devices().getMany({ testerId });
+  if (params.device?.toString() === "random" && userDevices.length) {
+    return userDevices[0].id;
+  }
+  return 0;
+};
 /** OPENAPI-ROUTE: post-campaigns-campaign-candidates */
 export default async (
   c: Context,
@@ -38,6 +49,8 @@ export default async (
       ? c.request.params.campaign
       : "-1"
   );
+  const params =
+    req.query as StoplightOperations["post-campaigns-campaign-candidates"]["parameters"]["query"];
   const testerId = body.tester_id;
   let tester;
   try {
@@ -54,10 +67,18 @@ export default async (
       message: (err as OpenapiError).message,
     };
   }
-
+  let selectedDeviceId;
   let candidature;
   try {
-    candidature = await createCandidature(tester.wp_user_id, campaignId);
+    selectedDeviceId = await getSelectedDeviceId(testerId, params);
+    candidature = await createCandidature(
+      tester.wp_user_id,
+      campaignId,
+      selectedDeviceId
+    );
+    if (candidature.device > 0) {
+      candidature.device = await new Devices().getOne(candidature.device);
+    }
   } catch (err) {
     debugMessage(err);
     res.status_code = (err as OpenapiError).status_code || 500;
@@ -82,6 +103,6 @@ export default async (
         : candidature.status === 3
         ? "completed"
         : "unknown",
-    device: candidature.device == 0 ? "any" : "invalid",
+    device: candidature.device == 0 ? "any" : candidature.device,
   };
 };

--- a/src/routes/users/me/certifications/_post/index.ts
+++ b/src/routes/users/me/certifications/_post/index.ts
@@ -90,7 +90,6 @@ async function assignCertification(
   let inserted;
   try {
     inserted = await db.query(db.format(insertSql, insertData));
-    console.log("INS: ", inserted);
     return inserted;
   } catch (e) {
     if (process.env && process.env.DEBUG) console.log(e);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1035,6 +1035,9 @@ export interface operations {
         /** A campaign id */
         campaign: string;
       };
+      query: {
+        device?: string;
+      };
     };
     responses: {
       /** OK */


### PR DESCRIPTION
### The selection API  must select a tryber for a CP with a random tryber-device if is set queryparameter ?device=random

**TESTING NOTES**

- if is set  ?device=random the selected_device -> one of tester devices

- if is set  ?device=random and tester has no devices, the selected_device = 0

- if is set  ?device={device_id} and tester has not device_id, return error

- if is set  ?device={device_id} and tester has device_id, the selected_device = device_id and return device

- if is not set  ?device=random the selected_device = 0