### PR TITLE
Return an error when campaign is already linked to another form

### DIFF
--- a/src/routes/campaigns/forms/_post/index.spec.ts
+++ b/src/routes/campaigns/forms/_post/index.spec.ts
@@ -58,7 +58,7 @@ describe("POST /campaigns/forms/", () => {
         "authorization",
         `Bearer tester capability ["manage_preselection_forms"]`
       );
-    const result = await PreselectionForm.all(["campaign_id"], [{ id: 1 }]);
+    const result = await PreselectionForm.all(undefined, [{ campaign_id: 1 }]);
     expect(result.length).toBe(1);
     expect(result[0]).toHaveProperty("campaign_id", body.campaign);
     const responseNewFormSameCamapign = await request(app)

--- a/src/routes/campaigns/forms/_post/index.spec.ts
+++ b/src/routes/campaigns/forms/_post/index.spec.ts
@@ -74,6 +74,11 @@ describe("POST /campaigns/forms/", () => {
     expect(afterNewFormResult.length).toBe(1);
     expect(afterNewFormResult[0]).toHaveProperty("campaign_id", body.campaign);
     expect(responseNewFormSameCamapign.status).toBe(406);
+    expect(responseNewFormSameCamapign.body).toMatchObject({
+      element: "element",
+      id: 1,
+      message: "A form is already assigned to this campaign_id",
+    });
   });
   it("Should create a new form on success and return its id", async () => {
     const response = await request(app)

--- a/src/routes/campaigns/forms/_post/index.spec.ts
+++ b/src/routes/campaigns/forms/_post/index.spec.ts
@@ -45,7 +45,36 @@ describe("POST /campaigns/forms/", () => {
       );
     expect(response.status).toBe(201);
   });
-
+  it("Should return 406 if sending a form associated with a campaign that already has a form", async () => {
+    const body = {
+      ...sampleBody,
+      fields: [],
+      campaign: 1,
+    };
+    await request(app)
+      .post("/campaigns/forms/")
+      .send(body)
+      .set(
+        "authorization",
+        `Bearer tester capability ["manage_preselection_forms"]`
+      );
+    const result = await PreselectionForm.all(["campaign_id"], [{ id: 1 }]);
+    expect(result.length).toBe(1);
+    expect(result[0]).toHaveProperty("campaign_id", body.campaign);
+    const responseNewFormSameCamapign = await request(app)
+      .post("/campaigns/forms/")
+      .send({ ...body, name: "New Form withsame campaign id" })
+      .set(
+        "authorization",
+        `Bearer tester capability ["manage_preselection_forms"]`
+      );
+    const afterNewFormResult = await PreselectionForm.all(undefined, [
+      { campaign_id: 1 },
+    ]);
+    expect(afterNewFormResult.length).toBe(1);
+    expect(afterNewFormResult[0]).toHaveProperty("campaign_id", body.campaign);
+    expect(responseNewFormSameCamapign.status).toBe(406);
+  });
   it("Should create a new form on success and return its id", async () => {
     const response = await request(app)
       .post("/campaigns/forms/")

--- a/src/routes/campaigns/forms/formId/_put/index.ts
+++ b/src/routes/campaigns/forms/formId/_put/index.ts
@@ -88,7 +88,9 @@ export default class RouteItem extends UserRoute<{
       data: {
         name,
         author: this.getTesterId(),
-        campaign_id: campaign ? campaign : undefined,
+        campaign_id: campaign
+          ? await this.getValidCampaignId(campaign)
+          : undefined,
       },
       where: [{ id: this.getId() }],
     });
@@ -127,5 +129,18 @@ export default class RouteItem extends UserRoute<{
           }
         : undefined,
     };
+  }
+
+  private async getValidCampaignId(campaign_id: number): Promise<number> {
+    const formWithCurrentCampaignId = await this.db.forms.query({
+      where: [{ campaign_id: campaign_id }],
+    });
+    if (formWithCurrentCampaignId.length !== 0) {
+      throw {
+        status_code: 406,
+        message: "A form is already assigned to this campaign_id",
+      };
+    }
+    return campaign_id;
   }
 }

--- a/src/routes/campaigns/forms/formId/_put/index.ts
+++ b/src/routes/campaigns/forms/formId/_put/index.ts
@@ -11,6 +11,7 @@ export default class RouteItem extends UserRoute<{
   parameters: StoplightOperations["put-campaigns-forms-formId"]["parameters"]["path"];
 }> {
   private campaignId: number | undefined;
+  private newCampaignId: number | undefined;
   private db: {
     forms: PreselectionForms;
     campaigns: Campaigns;
@@ -19,11 +20,13 @@ export default class RouteItem extends UserRoute<{
 
   constructor(options: RouteItem["configuration"]) {
     super(options);
+    const body = this.getBody();
     this.db = {
       forms: new PreselectionForms(),
       campaigns: new Campaigns(),
       fields: new PreselectionFormFields(),
     };
+    this.newCampaignId = body.campaign;
   }
 
   protected async init() {
@@ -55,6 +58,15 @@ export default class RouteItem extends UserRoute<{
     if (this.campaignId && !this.hasAccessToCampaign(this.campaignId)) {
       return this.setUnauthorizedError();
     }
+    if (await this.isCampaignIdAlreadyAssigned()) {
+      this.setError(
+        406,
+        new Error(
+          "A form is already assigned to this campaign_id"
+        ) as OpenapiError
+      );
+      return false;
+    }
     return true;
   }
 
@@ -83,14 +95,12 @@ export default class RouteItem extends UserRoute<{
   }
 
   private async editForm() {
-    const { name, campaign } = this.getBody();
+    const { name } = this.getBody();
     await this.db.forms.update({
       data: {
         name,
         author: this.getTesterId(),
-        campaign_id: campaign
-          ? await this.getValidCampaignId(campaign)
-          : undefined,
+        campaign_id: this.newCampaignId,
       },
       where: [{ id: this.getId() }],
     });
@@ -131,16 +141,12 @@ export default class RouteItem extends UserRoute<{
     };
   }
 
-  private async getValidCampaignId(campaign_id: number): Promise<number> {
+  private async isCampaignIdAlreadyAssigned(): Promise<boolean> {
+    if (this.newCampaignId === undefined) return false;
+
     const formWithCurrentCampaignId = await this.db.forms.query({
-      where: [{ campaign_id: campaign_id }],
+      where: [{ campaign_id: this.newCampaignId }],
     });
-    if (formWithCurrentCampaignId.length !== 0) {
-      throw {
-        status_code: 406,
-        message: "A form is already assigned to this campaign_id",
-      };
-    }
-    return campaign_id;
+    return formWithCurrentCampaignId.length !== 0;
   }
 }


### PR DESCRIPTION
 -  PUT a preselectionForm: Should return 406 if sending a form associated with a campaign that already has a form
 -  POST a preselectionForm: Should return 406 if sending a form associated with a campaign that already has a form