### PR TITLE
CP-2569-get-campaigns-campaignId-forms

### DIFF
--- a/getTestList.sh
+++ b/getTestList.sh
@@ -7,4 +7,4 @@ if [[ ! -z $1 ]]; then
 	FILTERS='| startswith("'"$1"'")'
 fi
 
-npm run -s test:ls $PARAMS | jq '.testResults[] | .assertionResults[] | select(.ancestorTitles[0] '"$FILTERS"' ) | .fullName'
+npm run -s test:ls  | jq '.testResults[] | .assertionResults[] | select(.ancestorTitles[0] '"$FILTERS"' ) | .fullName'

--- a/src/__mocks__/jsonwebtoken/index.ts
+++ b/src/__mocks__/jsonwebtoken/index.ts
@@ -96,7 +96,7 @@ class MockedVerifier {
   }
 
   private decodeOlps() {
-    const tokenItems = this.token.split(" ");
+    const tokenItems = this.token.replace(/ +/g, " ").split(" ");
     if (tokenItems.includes("olp")) {
       const capabilityIndex = tokenItems.indexOf("olp") + 1;
       if (capabilityIndex < tokenItems.length) {
@@ -115,7 +115,7 @@ class MockedVerifier {
   }
 
   private decodeCapabilities() {
-    const tokenItems = this.token.split(" ");
+    const tokenItems = this.token.replace(/ +/g, " ").split(" ");
     if (tokenItems.includes("capability")) {
       const capabilityIndex = tokenItems.indexOf("capability") + 1;
       if (capabilityIndex < tokenItems.length) {

--- a/src/features/db/class/PreselectionFormFields.ts
+++ b/src/features/db/class/PreselectionFormFields.ts
@@ -74,3 +74,4 @@ class Table extends Database<{
   }
 }
 export default Table;
+export { PreselectionFormFieldsObject };

--- a/src/features/routes/UserRoute.ts
+++ b/src/features/routes/UserRoute.ts
@@ -39,4 +39,10 @@ export default class UserRoute<T extends RouteClassTypes> extends Route<T> {
     if (!olp) return false;
     return olp === true || olp?.includes(campaignId);
   }
+  protected hasAccessTesterSelection(campaignId: number) {
+    const olp =
+      this.configuration.request.user.permission.admin?.appq_tester_selection;
+    if (!olp) return false;
+    return olp === true || olp?.includes(campaignId);
+  }
 }

--- a/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
@@ -4,17 +4,34 @@ import preselectionForm from "@src/__mocks__/mockedDb/preselectionForm";
 import preselectionFormFields from "@src/__mocks__/mockedDb/preselectionFormFields";
 describe("GET /campaigns/:campaignId/forms", () => {
   beforeAll(async () => {
-    await preselectionForm.insert({ id: 1, name: "Form Name1" });
-    await preselectionFormFields.insert({ id: 1, question: "Question Name1" });
+    await preselectionForm.insert({
+      id: 1,
+      name: "Form Name1",
+      campaign_id: 1,
+    });
+    await preselectionFormFields.insert({
+      id: 1,
+      form_id: 1,
+      question: "Question Name1",
+    });
     await preselectionFormFields.insert({
       id: 2,
+      form_id: 1,
       question: "Question Name2",
       short_name: "question_short_2",
       priority: 2,
     });
     await preselectionFormFields.insert({
       id: 3,
+      form_id: 1,
       question: "Question Name3",
+      short_name: "question_short_3",
+      priority: 1,
+    });
+    await preselectionFormFields.insert({
+      id: 4,
+      form_id: 2,
+      question: "Question Name from form2",
       short_name: "question_short_3",
       priority: 1,
     });

--- a/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
@@ -1,0 +1,85 @@
+import request from "supertest";
+import app from "@src/app";
+import preselectionForm from "@src/__mocks__/mockedDb/preselectionForm";
+import preselectionFormFields from "@src/__mocks__/mockedDb/preselectionFormFields";
+describe("GET /campaigns/forms ", () => {
+  beforeAll(async () => {
+    await preselectionForm.insert({ id: 1, name: "Form Name1" });
+    await preselectionFormFields.insert({ id: 1, question: "Question Name1" });
+    await preselectionFormFields.insert({
+      id: 2,
+      question: "Question Name2",
+      short_name: "question_short_2",
+      priority: 2,
+    });
+    await preselectionFormFields.insert({
+      id: 3,
+      question: "Question Name3",
+      short_name: "question_short_3",
+      priority: 1,
+    });
+  });
+  afterAll(async () => {
+    await preselectionForm.clear();
+    await preselectionFormFields.clear();
+  });
+  it("should answer 403 if user is not logged in ", async () => {
+    const response = await request(app).get("/campaigns/1/forms/");
+    expect(response.status).toBe(403);
+  });
+  it("should answer 403 if user is logged in without olp appq_tester_selection", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester`);
+    expect(response.status).toBe(403);
+  });
+  it("should answer 200 if user is logged in and has olp appq_tester_selection ", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester olp {"appq_tester_selection":true}`);
+    expect(response.status).toBe(200);
+  });
+  it("should return 403 if user does not have access to campaign", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester olp {"appq_tester_selection":[2]}`);
+    expect(response.status).toBe(403);
+  });
+  it("should return 200 if user has access to single campaign", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester olp {"appq_tester_selection":[1]}`);
+    expect(response.status).toBe(200);
+  });
+  it("should return questions", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester olp {"appq_tester_selection":true}`);
+    expect(response.body.length).toBe(3);
+    expect(response.body).toEqual(
+      expect.arrayContaining([
+        { id: 1, question: "Question Name1" },
+        { id: 2, question: "Question Name2", short_name: "question_short_2" },
+        { id: 3, question: "Question Name3", short_name: "question_short_3" },
+      ])
+    );
+  });
+  it("should return questions ordered by priority", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester olp {"appq_tester_selection":true}`);
+    console.log(response.body);
+    expect(response.body.length).toBe(3);
+    expect(response.body[0]).toHaveProperty("id", 1);
+    expect(response.body[1]).toHaveProperty("id", 3);
+    expect(response.body[2]).toHaveProperty("id", 2);
+  });
+});
+describe("GET /campaigns/forms when no data", () => {
+  it("should answer 403 if there are no data", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/forms/")
+      .set("authorization", `Bearer tester olp {"appq_tester_selection":true}`);
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
@@ -93,6 +93,15 @@ describe("GET /campaigns/:campaignId/forms", () => {
     expect(response.body[1]).toHaveProperty("id", 3);
     expect(response.body[2]).toHaveProperty("id", 2);
   });
+  it("should return 404 if campaign has no form", async () => {
+    const response = await request(app)
+      .get("/campaigns/2/forms/")
+      .set(
+        "authorization",
+        `Bearer tester olp    {"appq_tester_selection":true}`
+      );
+    expect(response.status).toBe(404);
+  });
 });
 describe("GET /campaigns/:campaignId/forms when no data", () => {
   it("should answer 403 if there are no data", async () => {

--- a/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 import app from "@src/app";
 import preselectionForm from "@src/__mocks__/mockedDb/preselectionForm";
 import preselectionFormFields from "@src/__mocks__/mockedDb/preselectionFormFields";
-describe("GET /campaigns/forms ", () => {
+describe("GET /campaigns/:campaignId/forms", () => {
   beforeAll(async () => {
     await preselectionForm.insert({ id: 1, name: "Form Name1" });
     await preselectionFormFields.insert({ id: 1, question: "Question Name1" });
@@ -77,7 +77,7 @@ describe("GET /campaigns/forms ", () => {
     expect(response.body[2]).toHaveProperty("id", 2);
   });
 });
-describe("GET /campaigns/forms when no data", () => {
+describe("GET /campaigns/:campaignId/forms when no data", () => {
   it("should answer 403 if there are no data", async () => {
     const response = await request(app)
       .get("/campaigns/1/forms/")

--- a/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.spec.ts
@@ -67,8 +67,10 @@ describe("GET /campaigns/forms ", () => {
   it("should return questions ordered by priority", async () => {
     const response = await request(app)
       .get("/campaigns/1/forms/")
-      .set("authorization", `Bearer tester olp {"appq_tester_selection":true}`);
-    console.log(response.body);
+      .set(
+        "authorization",
+        `Bearer tester olp    {"appq_tester_selection":true}`
+      );
     expect(response.body.length).toBe(3);
     expect(response.body[0]).toHaveProperty("id", 1);
     expect(response.body[1]).toHaveProperty("id", 3);

--- a/src/routes/campaigns/campaignId/forms/_get/index.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.ts
@@ -1,0 +1,59 @@
+/** OPENAPI-CLASS: get-campaigns-campaign-forms */
+import UserRoute from "@src/features/routes/UserRoute";
+import PreselectionFormFields, {
+  PreselectionFormFieldsObject,
+} from "@src/features/db/class/PreselectionFormFields";
+import OpenapiError from "@src/features/OpenapiError";
+
+export default class RouteItem extends UserRoute<{
+  response: StoplightOperations["get-campaigns-campaign-forms"]["responses"][200]["content"]["application/json"];
+  parameters: StoplightOperations["get-campaigns-campaign-forms"]["parameters"]["path"];
+}> {
+  private db: { questions: PreselectionFormFields };
+  private campaign_id: number;
+  private questions: PreselectionFormFieldsObject[] | false = false;
+
+  constructor(config: RouteClassConfiguration) {
+    super(config);
+    const parameters = this.getParameters();
+    this.campaign_id = parseInt(parameters.campaign);
+    this.db = {
+      questions: new PreselectionFormFields(["id", "question", "short_name"]),
+    };
+  }
+  protected async init() {
+    this.questions = await this.db.questions.query({
+      orderBy: [{ field: "priority" }],
+    });
+    if (this.questions.length === 0) {
+      this.questions = false;
+    }
+  }
+
+  protected async filter() {
+    if (this.hasAccessTesterSelection(this.campaign_id) === false) {
+      this.setError(403, new Error("You are not authorized.") as OpenapiError);
+      return false;
+    }
+    return true;
+  }
+
+  protected async prepare() {
+    if (this.getQuestions().length === 0) {
+      return this.setError(404, new OpenapiError("No data found"));
+    }
+    this.setSuccess(200, this.getQuestions());
+  }
+
+  private getQuestions() {
+    if (this.questions === false) return [];
+    return this.questions.map((question) => {
+      return {
+        id: question.id,
+        short_name:
+          question.short_name !== null ? question.short_name : undefined,
+        question: question.question,
+      };
+    });
+  }
+}

--- a/src/routes/campaigns/campaignId/forms/_get/index.ts
+++ b/src/routes/campaigns/campaignId/forms/_get/index.ts
@@ -3,14 +3,16 @@ import UserRoute from "@src/features/routes/UserRoute";
 import PreselectionFormFields, {
   PreselectionFormFieldsObject,
 } from "@src/features/db/class/PreselectionFormFields";
+import PreselectionForm from "@src/features/db/class/PreselectionForms";
 import OpenapiError from "@src/features/OpenapiError";
 
 export default class RouteItem extends UserRoute<{
   response: StoplightOperations["get-campaigns-campaign-forms"]["responses"][200]["content"]["application/json"];
   parameters: StoplightOperations["get-campaigns-campaign-forms"]["parameters"]["path"];
 }> {
-  private db: { questions: PreselectionFormFields };
+  private db: { questions: PreselectionFormFields; form_id: PreselectionForm };
   private campaign_id: number;
+  private form_id: number = 0;
   private questions: PreselectionFormFieldsObject[] | false = false;
 
   constructor(config: RouteClassConfiguration) {
@@ -19,10 +21,21 @@ export default class RouteItem extends UserRoute<{
     this.campaign_id = parseInt(parameters.campaign);
     this.db = {
       questions: new PreselectionFormFields(["id", "question", "short_name"]),
+      form_id: new PreselectionForm(["id"]),
     };
   }
   protected async init() {
+    const forms = await this.db.form_id.query({
+      where: [{ campaign_id: this.campaign_id }],
+    });
+    if (forms.length === 0) {
+      this.form_id = 0;
+    } else {
+      this.form_id = forms[0].id;
+    }
+
     this.questions = await this.db.questions.query({
+      where: [{ form_id: this.form_id }],
       orderBy: [{ field: "priority" }],
     });
     if (this.questions.length === 0) {
@@ -34,6 +47,12 @@ export default class RouteItem extends UserRoute<{
     if (this.hasAccessTesterSelection(this.campaign_id) === false) {
       this.setError(403, new Error("You are not authorized.") as OpenapiError);
       return false;
+    }
+    if (this.form_id === 0) {
+      this.setError(
+        404,
+        new Error("No form for this campaign.") as OpenapiError
+      );
     }
     return true;
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -37,6 +37,7 @@ declare global {
         appq_prospect?: Olp;
         appq_message_center?: Olp;
         appq_campaign?: Olp;
+        appq_tester_selection?: Olp;
       };
     };
   };


### PR DESCRIPTION
 - GET /campaigns/:campaignId/forms should answer 403 if user is not logged in
 - GET /campaigns/:campaignId/forms should answer 403 if user is logged in without olp appq_tester_selection
 - GET /campaigns/:campaignId/forms should answer 200 if user is logged in and has olp appq_tester_selection
 - GET /campaigns/:campaignId/forms should return 403 if user does not have access to campaign
 - GET /campaigns/:campaignId/forms should return 200 if user has access to single campaign
 - GET /campaigns/:campaignId/forms should return questions
 - GET /campaigns/:campaignId/forms should return questions ordered by priority
 - GET /campaigns/:campaignId/forms should return 404 if campaign has no form
 - GET /campaigns/:campaignId/forms when no data should answer 403 if there are no data