### PR TITLE
feat(prospect): add support for max bonus bug payout limit

### DIFF
--- a/src/routes/campaigns/campaignId/prospect/_get/prospectdata.spec.ts
+++ b/src/routes/campaigns/campaignId/prospect/_get/prospectdata.spec.ts
@@ -194,3 +194,35 @@ describe("GET /campaigns/campaignId/prospect - there are no record", () => {
     );
   });
 });
+
+describe("GET /campaigns/campaignId/prospect - should cap at bonus bug", () => {
+  beforeAll(async () => {
+    await tryber.tables.WpAppqProspectPayout.do().insert({
+      id: 1,
+      campaign_id: 1,
+      tester_id: 1,
+      complete_pts: 100,
+      extra_pts: 69,
+      complete_eur: 25,
+      bonus_bug_eur: 2000,
+      extra_eur: 9,
+      refund: 1,
+      notes: "This is the notes",
+      is_edit: 0,
+      is_completed: 1,
+    });
+  });
+  it("Should return capped bonus bug", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/prospect")
+      .set("Authorization", 'Bearer tester olp {"appq_tester_selection":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tester: expect.objectContaining({ id: 1 }),
+          payout: expect.objectContaining({ bug: 30 }),
+        }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
Add support for max bonus bug payout limit in the ProspectRoute class. If the payout limit is set, the bonus bug payout will be capped at the limit.

Add a test case to ensure that the bonus bug payout is capped at the limit.