### PR TITLE
improve query get-users-me-bugs

### DIFF
--- a/src/routes/users/me/bugs/_get/index.ts
+++ b/src/routes/users/me/bugs/_get/index.ts
@@ -12,11 +12,11 @@ export default async (
     const sqlSelectFields = `SELECT 
        b.id as id, s.id as severityID, s.name as severity, 
        st.id as statusID, st.name as status, 
-       c.title as campaignTITLE, c.id as campaign, b.message as title`;
+       IFNULL(c.title, "Deleted CP") as campaignTITLE, IFNULL(c.id, "Deleted CP") as campaign, b.message as title`;
 
     let fromSql = `
     FROM wp_appq_evd_bug b
-             JOIN wp_appq_evd_campaign c ON (c.id = b.campaign_id)
+             LEFT JOIN wp_appq_evd_campaign c ON (c.id = b.campaign_id)
              JOIN wp_appq_evd_severity s ON (s.id = b.severity_id)
              JOIN wp_appq_evd_bug_status st ON (st.id = b.status_id)
  WHERE b.wp_user_id  = ?`;


### PR DESCRIPTION
- I modified the JOIN between the bug and the campaign tables to **LEFT JOIN** because there might -_rarely_- be some **deleted CPs** in the past (I noticed it on my profile with some **missing CP** [and some derived bugs data] in _2017_) and so the JOIN could **return less rows than expected**.
Having only a JOIN would have not matched those rows because there was no occurrence of the same cpid in the table on the right side, although the `count(b.id)` would have been a **correct total value** because the bug ids are still all stored correctly. 
_Seems like that the other fields about the bugs from deleted CPs are also stored correctly (title, severity, etc)._ 

- Moreover I added an **IFNULL** function in the SELECT statement (`sqlSelectFields`) to avoid ugly null values to be displayed.

Hope it helps!

![bugs](https://user-images.githubusercontent.com/34134474/233749651-385ca141-32a6-49eb-abcf-0e5e3fc5ac15.jpg)


![bugs2](https://user-images.githubusercontent.com/34134474/233751068-2f9cc188-939e-44c7-9936-73026f5b0fb7.png)