### PR TITLE
fix(security-handler): prevent cookies checks if an apikey is present

### DIFF
--- a/src/middleware/jwtSecurityHandler.ts
+++ b/src/middleware/jwtSecurityHandler.ts
@@ -12,7 +12,8 @@ export default async (
   if (Array.isArray(authHeader)) {
     authHeader = authHeader.join(" ");
   }
-  if (!authHeader) {
+
+  if (!authHeader && "apikey" in c.request.headers === false) {
     const user = await checkCookies(req);
     if (user instanceof Error) {
       return jwt.verify("", config.jwt.secret);


### PR DESCRIPTION
Purtroppo entrambi i security handler andavano a modificare il `req.user`, in presenza di due middleware con successo (utente loggato che usa apikey), l'utente risultante era quello risultante dal middleware più lento (l'ultimo a modificare il req.user).

Non sono felice della soluzione ma per il momento è l'unica che ci permette di andare in prod