### PR TITLE
 check-start-expiration-dates

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -8207,8 +8207,10 @@ components:
           type: number
         startDate:
           type: string
+          pattern: '^[0-9]{4}-(0[0-9]|1[0-2])-([0-1][0-9]|3[0-1])$'
         expirationDate:
           type: string
+          pattern: '^[0-9]{4}-(0[0-9]|1[0-2])-([0-1][0-9]|3[0-1])$'
         note:
           type: string
         isTokenBased:

--- a/src/routes/agreements/_get/index.spec.ts
+++ b/src/routes/agreements/_get/index.spec.ts
@@ -1,5 +1,5 @@
-import request from "supertest";
 import app from "@src/app";
+import request from "supertest";
 import useAgreementsData from "./useAgreementsData";
 
 describe("GET /agreements", () => {
@@ -156,15 +156,15 @@ describe("GET /agreements", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 9,
-          startDate: "2021-01-01 00:00:00",
+          startDate: "2021-01-01",
         }),
         expect.objectContaining({
           id: 10,
-          startDate: "2021-01-01 00:00:00",
+          startDate: "2021-01-01",
         }),
         expect.objectContaining({
           id: 11,
-          startDate: "2021-01-01 00:00:00",
+          startDate: "2021-01-01",
         }),
       ])
     );
@@ -178,15 +178,15 @@ describe("GET /agreements", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 9,
-          expirationDate: "2021-01-10 00:00:00",
+          expirationDate: "2021-01-10",
         }),
         expect.objectContaining({
           id: 10,
-          expirationDate: "2021-01-10 00:00:00",
+          expirationDate: "2021-01-10",
         }),
         expect.objectContaining({
           id: 11,
-          expirationDate: "2021-01-10 00:00:00",
+          expirationDate: "2021-01-10",
         }),
       ])
     );
@@ -287,8 +287,8 @@ describe("GET /agreements filtered by customerId", () => {
         title: "Title Agreement11",
         tokens: 111,
         unitPrice: 165,
-        startDate: "2021-01-01 00:00:00",
-        expirationDate: "2021-01-10 00:00:00",
+        startDate: "2021-01-01",
+        expirationDate: "2021-01-10",
         note: "Notes Agreement11",
         customer: {
           id: 11,

--- a/src/routes/agreements/_get/index.ts
+++ b/src/routes/agreements/_get/index.ts
@@ -110,7 +110,7 @@ export default class SingleCampaignRoute extends UserRoute<{
     if (agreements.length === 0) return { data: [], total };
 
     const data = (
-      agreements as (typeof agreements[number] & {
+      agreements as ((typeof agreements)[number] & {
         startDate: string;
         expirationDate: string;
       })[]
@@ -119,8 +119,8 @@ export default class SingleCampaignRoute extends UserRoute<{
       title: agreement.title,
       tokens: agreement.tokens,
       unitPrice: agreement.unitPrice,
-      startDate: agreement.startDate,
-      expirationDate: agreement.expirationDate,
+      startDate: agreement.startDate.split(" ")[0],
+      expirationDate: agreement.expirationDate.split(" ")[0],
       customer: {
         id: agreement.customer_id,
         company: agreement.company,
@@ -128,6 +128,7 @@ export default class SingleCampaignRoute extends UserRoute<{
       note: agreement.note.length > 0 ? agreement.note : undefined,
       isTokenBased: agreement.isTokenBased > 0 ? true : false,
     }));
+    console.log(data);
 
     return { data, total };
   }

--- a/src/routes/agreements/_post/index.spec.ts
+++ b/src/routes/agreements/_post/index.spec.ts
@@ -43,6 +43,35 @@ describe("POST /agreements", () => {
       .send(basicPostData);
     expect(response.status).toBe(403);
   });
+
+  it("Should return 400 if send a bad startDate", async () => {
+    const responseBadDate = await request(app)
+      .post("/agreements")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPostData, startDate: "badDate" });
+    expect(responseBadDate.status).toBe(400);
+
+    const responseBadDatetime = await request(app)
+      .post("/agreements")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPostData, startDate: "2020-01-01 badTime" });
+    expect(responseBadDatetime.status).toBe(400);
+  });
+
+  it("Should return 400 if send a bad expirationDate", async () => {
+    const responseBadDate = await request(app)
+      .post("/agreements")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPostData, expirationDate: "badDate" });
+    expect(responseBadDate.status).toBe(400);
+
+    const responseBadDatetime = await request(app)
+      .post("/agreements")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPostData, expirationDate: "2020-01-01 badTime" });
+    expect(responseBadDatetime.status).toBe(400);
+  });
+
   it("Should return 200 if logged in as user with full access to campaign", async () => {
     const response = await request(app)
       .post("/agreements")
@@ -59,7 +88,6 @@ describe("POST /agreements", () => {
       .post("/agreements")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
       .send(basicPostData);
-    console.log(response.body);
     const agreementsAfter = await tryber.tables.FinanceAgreements.do().select(
       "id"
     );

--- a/src/routes/agreements/_post/index.spec.ts
+++ b/src/routes/agreements/_post/index.spec.ts
@@ -44,7 +44,7 @@ describe("POST /agreements", () => {
     expect(response.status).toBe(403);
   });
 
-  it("Should return 400 if send a bad startDate", async () => {
+  it("Should return 400 if send a startDate that's not YYYY-mm-dd", async () => {
     const responseBadDate = await request(app)
       .post("/agreements")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
@@ -58,7 +58,7 @@ describe("POST /agreements", () => {
     expect(responseBadDatetime.status).toBe(400);
   });
 
-  it("Should return 400 if send a bad expirationDate", async () => {
+  it("Should return 400 if send a expirationDate that's not YYYY-mm-dd", async () => {
     const responseBadDate = await request(app)
       .post("/agreements")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')

--- a/src/routes/agreements/_post/index.ts
+++ b/src/routes/agreements/_post/index.ts
@@ -18,29 +18,7 @@ export default class Route extends UserRoute<{
       this.setError(403, new OpenapiError("Customer not found"));
       return false;
     }
-    if ((await this.dateIsAcceptable(this.getBody().startDate)) === false) {
-      return this.badRequestResponse();
-    }
-
-    if (
-      (await this.dateIsAcceptable(this.getBody().expirationDate)) === false
-    ) {
-      return this.badRequestResponse();
-    }
     return true;
-  }
-
-  private async dateIsAcceptable(date: string) {
-    //startDate respect regular expression  "YYYY-mm-dd";
-    const dateRegex = new RegExp(
-      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$"
-    );
-    //startDate respect datetime  regular expression  "YYYY-mm-dd hh:mm:ss";
-    const dateTimeRegex = new RegExp(
-      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])[ ]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$"
-    );
-
-    return dateRegex.test(date) || dateTimeRegex.test(date);
   }
 
   private async customerExists() {
@@ -50,10 +28,6 @@ export default class Route extends UserRoute<{
         id: this.getBody().customerId,
       });
     return customer.length !== 0;
-  }
-  private badRequestResponse() {
-    this.setError(400, new OpenapiError("Bad Request"));
-    return false;
   }
 
   protected async prepare() {

--- a/src/routes/agreements/_post/index.ts
+++ b/src/routes/agreements/_post/index.ts
@@ -18,7 +18,29 @@ export default class Route extends UserRoute<{
       this.setError(403, new OpenapiError("Customer not found"));
       return false;
     }
+    if ((await this.dateIsAcceptable(this.getBody().startDate)) === false) {
+      return this.badRequestResponse();
+    }
+
+    if (
+      (await this.dateIsAcceptable(this.getBody().expirationDate)) === false
+    ) {
+      return this.badRequestResponse();
+    }
     return true;
+  }
+
+  private async dateIsAcceptable(date: string) {
+    //startDate respect regular expression  "YYYY-mm-dd";
+    const dateRegex = new RegExp(
+      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$"
+    );
+    //startDate respect datetime  regular expression  "YYYY-mm-dd hh:mm:ss";
+    const dateTimeRegex = new RegExp(
+      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])[ ]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$"
+    );
+
+    return dateRegex.test(date) || dateTimeRegex.test(date);
   }
 
   private async customerExists() {
@@ -28,6 +50,10 @@ export default class Route extends UserRoute<{
         id: this.getBody().customerId,
       });
     return customer.length !== 0;
+  }
+  private badRequestResponse() {
+    this.setError(400, new OpenapiError("Bad Request"));
+    return false;
   }
 
   protected async prepare() {

--- a/src/routes/agreements/agreementId/_put/index.spec.ts
+++ b/src/routes/agreements/agreementId/_put/index.spec.ts
@@ -64,6 +64,34 @@ describe("PUT /agreements/{agreementId}", () => {
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1,2]}');
     expect(response.status).toBe(403);
   });
+  it("Should return 400 if send a bad startDate", async () => {
+    const responseBadDate = await request(app)
+      .put("/agreements/1")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPutData, startDate: "badDate" });
+    expect(responseBadDate.status).toBe(400);
+
+    const responseBadDatetime = await request(app)
+      .put("/agreements/1")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPutData, startDate: "2020-01-01 badTime" });
+    expect(responseBadDatetime.status).toBe(400);
+  });
+
+  it("Should return 400 if send a bad expirationDate", async () => {
+    const responseBadDate = await request(app)
+      .put("/agreements/1")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPutData, expirationDate: "badDate" });
+    expect(responseBadDate.status).toBe(400);
+
+    const responseBadDatetime = await request(app)
+      .put("/agreements/1")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
+      .send({ ...basicPutData, expirationDate: "2020-01-01 badTime" });
+    expect(responseBadDatetime.status).toBe(400);
+  });
+
   it("Should return 200 if logged in as user with full access to campaign", async () => {
     const response = await request(app)
       .put("/agreements/1")

--- a/src/routes/agreements/agreementId/_put/index.spec.ts
+++ b/src/routes/agreements/agreementId/_put/index.spec.ts
@@ -64,7 +64,7 @@ describe("PUT /agreements/{agreementId}", () => {
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1,2]}');
     expect(response.status).toBe(403);
   });
-  it("Should return 400 if send a bad startDate", async () => {
+  it("Should return 400 if send a startDate that's not YYYY-mm-dd", async () => {
     const responseBadDate = await request(app)
       .put("/agreements/1")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')
@@ -78,7 +78,7 @@ describe("PUT /agreements/{agreementId}", () => {
     expect(responseBadDatetime.status).toBe(400);
   });
 
-  it("Should return 400 if send a bad expirationDate", async () => {
+  it("Should return 400 if send a expirationDate that's not YYYY-mm-dd", async () => {
     const responseBadDate = await request(app)
       .put("/agreements/1")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":true}')

--- a/src/routes/agreements/agreementId/_put/index.ts
+++ b/src/routes/agreements/agreementId/_put/index.ts
@@ -29,15 +29,6 @@ export default class Route extends UserRoute<{
     if ((await this.customerExists()) === false) {
       return this.forbiddenResponse();
     }
-    if ((await this.dateIsAcceptable(this.getBody().startDate)) === false) {
-      return this.badRequestResponse();
-    }
-
-    if (
-      (await this.dateIsAcceptable(this.getBody().expirationDate)) === false
-    ) {
-      return this.badRequestResponse();
-    }
 
     return true;
   }
@@ -60,25 +51,8 @@ export default class Route extends UserRoute<{
     return customer.length !== 0;
   }
 
-  private async dateIsAcceptable(date: string) {
-    //startDate respect regular expression  "YYYY-mm-dd";
-    const dateRegex = new RegExp(
-      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$"
-    );
-    //startDate respect datetime  regular expression  "YYYY-mm-dd hh:mm:ss";
-    const dateTimeRegex = new RegExp(
-      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])[ ]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$"
-    );
-
-    return dateRegex.test(date) || dateTimeRegex.test(date);
-  }
-
   private forbiddenResponse() {
     this.setError(403, new OpenapiError("Forbidden"));
-    return false;
-  }
-  private badRequestResponse() {
-    this.setError(400, new OpenapiError("Bad Request"));
     return false;
   }
 

--- a/src/routes/agreements/agreementId/_put/index.ts
+++ b/src/routes/agreements/agreementId/_put/index.ts
@@ -29,6 +29,16 @@ export default class Route extends UserRoute<{
     if ((await this.customerExists()) === false) {
       return this.forbiddenResponse();
     }
+    if ((await this.dateIsAcceptable(this.getBody().startDate)) === false) {
+      return this.badRequestResponse();
+    }
+
+    if (
+      (await this.dateIsAcceptable(this.getBody().expirationDate)) === false
+    ) {
+      return this.badRequestResponse();
+    }
+
     return true;
   }
 
@@ -50,8 +60,25 @@ export default class Route extends UserRoute<{
     return customer.length !== 0;
   }
 
+  private async dateIsAcceptable(date: string) {
+    //startDate respect regular expression  "YYYY-mm-dd";
+    const dateRegex = new RegExp(
+      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$"
+    );
+    //startDate respect datetime  regular expression  "YYYY-mm-dd hh:mm:ss";
+    const dateTimeRegex = new RegExp(
+      "^(19|20)\\d\\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])[ ]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$"
+    );
+
+    return dateRegex.test(date) || dateTimeRegex.test(date);
+  }
+
   private forbiddenResponse() {
     this.setError(403, new OpenapiError("Forbidden"));
+    return false;
+  }
+  private badRequestResponse() {
+    this.setError(400, new OpenapiError("Bad Request"));
     return false;
   }
 


### PR DESCRIPTION
- POST /agreements 
  - check-in request if startDate and expirationDate respect formats "YYYY-mm-dd hh:mm:ss" or  "YYYY-mm-dd"
  - otherwise, returns 400 incorrect request
- PUT /agreements/:id
  - check-in request if startDate and expirationDate respect formats "YYYY-mm-dd hh:mm:ss" or  "YYYY-mm-dd"
  - otherwise, returns 400 incorrect request
