### PR TITLE
Get observations

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -3237,7 +3237,10 @@ paths:
       description: Get observations for a campaign
       security:
         - JWT: []
-      parameters: []
+      parameters:
+        - schema: {}
+          in: query
+          name: filterBy
   /campaigns/forms:
     post:
       summary: Create a new preselection form

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -81,4 +81,16 @@ describe("GET /campaigns/:campaignId/observations", () => {
       ])
     );
   });
+  it("Should return items with name", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+        }),
+      ])
+    );
+  });
 });

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -36,7 +36,6 @@ describe("GET /campaigns/:campaignId/observations", () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
-    console.log(response.body);
     expect(response.status).toBe(200);
   });
 
@@ -44,7 +43,6 @@ describe("GET /campaigns/:campaignId/observations", () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":true}');
-    console.log(response.body);
     expect(response.status).toBe(200);
   });
 
@@ -52,7 +50,6 @@ describe("GET /campaigns/:campaignId/observations", () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", "Bearer admin");
-    console.log(response.body);
     expect(response.status).toBe(200);
   });
 });

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -55,6 +55,7 @@ beforeAll(async () => {
     {
       id: 10,
       campaign_id: 1,
+      cluster_id: 10,
       title: "Campaign Task1 title",
       simple_title: "Campaign Task1 simple_title",
       content: "Campaign Task1 content",
@@ -67,6 +68,7 @@ beforeAll(async () => {
     {
       id: 20,
       campaign_id: 2,
+      cluster_id: 20,
       title: "Campaign Task2 title",
       simple_title: "Campaign Task2 simple_title",
       content: "Campaign Task2 content",
@@ -75,6 +77,20 @@ beforeAll(async () => {
       is_required: 0,
       jf_code: "Campaign Task2 jf_code",
       jf_text: "Campaign Task2 jf_text",
+    },
+  ]);
+  await tryber.tables.WpAppqUsecaseCluster.do().insert([
+    {
+      id: 10,
+      campaign_id: 1,
+      title: "Cluster10 title",
+      subtitle: "Cluster10 subtitle",
+    },
+    {
+      id: 20,
+      campaign_id: 2,
+      title: "Cluster20 title",
+      subtitle: "Cluster20 subtitle",
     },
   ]);
 });
@@ -144,7 +160,6 @@ describe("GET /campaigns/:campaignId/observations", () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
-    console.log(response.body.items);
     expect(response.body.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -197,6 +212,37 @@ describe("GET /campaigns/:campaignId/observations", () => {
       expect.arrayContaining([
         expect.objectContaining({
           time: 59,
+        }),
+      ])
+    );
+  });
+
+  it("Should return items with cluster as id number and name string", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cluster: expect.objectContaining({
+            id: expect.any(Number),
+            name: expect.any(String),
+          }),
+        }),
+      ])
+    );
+  });
+  it("Should return items with cluster", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cluster: expect.objectContaining({
+            id: 10,
+            name: "Cluster10 title",
+          }),
         }),
       ])
     );

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -125,11 +125,10 @@ describe("GET /campaigns/:campaignId/observations", () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
-    console.log(response.body.items);
     expect(response.body.items.length).toBe(1);
   });
 
-  it("Should return items with id", async () => {
+  it("Should return items with id as number", async () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
@@ -141,7 +140,20 @@ describe("GET /campaigns/:campaignId/observations", () => {
       ])
     );
   });
-  it("Should return items with name", async () => {
+  it("Should return items with id", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    console.log(response.body.items);
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 1,
+        }),
+      ])
+    );
+  });
+  it("Should return items with name as string", async () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
@@ -153,7 +165,19 @@ describe("GET /campaigns/:campaignId/observations", () => {
       ])
     );
   });
-  it("Should return items with time", async () => {
+  it("Should return items with name", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Observation1 name",
+        }),
+      ])
+    );
+  });
+  it("Should return items with time as number", async () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
@@ -161,6 +185,18 @@ describe("GET /campaigns/:campaignId/observations", () => {
       expect.arrayContaining([
         expect.objectContaining({
           time: expect.any(Number),
+        }),
+      ])
+    );
+  });
+  it("Should return items with time", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          time: 59,
         }),
       ])
     );

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -288,3 +288,24 @@ describe("GET /campaigns/:campaignId/observations", () => {
     );
   });
 });
+
+describe("GET /campaigns/:campaignId/observations - there are no observation", () => {
+  beforeAll(async () => {
+    await tryber.tables.WpAppqUsecaseMediaObservations.do().delete();
+  });
+  it("Should return items array", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body).toHaveProperty("items");
+    expect(response.body.items).toBeInstanceOf(Array);
+  });
+
+  it("Should return items as empty array if there are no obeservations", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body).toHaveProperty("items");
+    expect(response.body.items).toEqual([]);
+  });
+});

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -1,6 +1,6 @@
-import request from "supertest";
 import app from "@src/app";
 import { tryber } from "@src/features/database";
+import request from "supertest";
 
 beforeAll(async () => {
   await tryber.tables.WpAppqEvdCampaign.do().insert({
@@ -301,7 +301,7 @@ describe("GET /campaigns/:campaignId/observations - there are no observation", (
     expect(response.body.items).toBeInstanceOf(Array);
   });
 
-  it("Should return items as empty array if there are no obeservations", async () => {
+  it("Should return items as empty array if there are no observations", async () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -17,6 +17,14 @@ beforeAll(async () => {
     customer_title: "",
     campaign_pts: 200,
   });
+  await tryber.tables.WpAppqEvdProfile.do().insert({
+    id: 1,
+    wp_user_id: 1,
+    name: "Tester1",
+    email: "jhon.doe@tryber.me",
+    employment_id: 1,
+    education_id: 1,
+  });
   await tryber.tables.WpAppqUsecaseMediaObservations.do().insert([
     {
       id: 1,
@@ -242,6 +250,38 @@ describe("GET /campaigns/:campaignId/observations", () => {
           cluster: expect.objectContaining({
             id: 10,
             name: "Cluster10 title",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("Should return items with tester as id number and name string", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tester: expect.objectContaining({
+            id: expect.any(Number),
+            name: expect.any(String),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("Should return items with tester", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tester: expect.objectContaining({
+            id: 1,
+            name: "Tester1",
           }),
         }),
       ])

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -52,4 +52,11 @@ describe("GET /campaigns/:campaignId/observations", () => {
       .set("Authorization", "Bearer admin");
     expect(response.status).toBe(200);
   });
+
+  it("Should return items array", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body).toHaveProperty("items", []);
+  });
 });

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -1,0 +1,58 @@
+import request from "supertest";
+import app from "@src/app";
+import { tryber } from "@src/features/database";
+
+beforeAll(async () => {
+  await tryber.tables.WpAppqEvdCampaign.do().insert({
+    id: 1,
+    platform_id: 1,
+    start_date: "2020-01-01",
+    end_date: "2020-01-01",
+    title: "This is the title",
+    page_preview_id: 1,
+    page_manual_id: 1,
+    customer_id: 1,
+    pm_id: 1,
+    project_id: 1,
+    customer_title: "",
+    campaign_pts: 200,
+  });
+});
+describe("GET /campaigns/:campaignId/observations", () => {
+  it("Should return 400 if campaign does not exist", async () => {
+    const response = await request(app)
+      .get("/campaigns/999/observations")
+      .set("Authorization", "Bearer admin");
+    expect(response.status).toBe(400);
+  });
+  it("Should return 403 if the user does not have permission", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", "Bearer tester");
+    expect(response.status).toBe(403);
+  });
+
+  it("Should return 200 if the user have olp permission on CP", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    console.log(response.body);
+    expect(response.status).toBe(200);
+  });
+
+  it("Should return 200 if the user have olp permission on all CP", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}');
+    console.log(response.body);
+    expect(response.status).toBe(200);
+  });
+
+  it("Should return 200 if the user is admin", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", "Bearer admin");
+    console.log(response.body);
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -20,10 +20,10 @@ beforeAll(async () => {
   await tryber.tables.WpAppqUsecaseMediaObservations.do().insert({
     id: 1,
     media_id: 1,
-    name: "name",
-    video_ts: 0,
-    description: "description",
-    ux_note: "ux_notes",
+    name: "Observation name",
+    video_ts: 59,
+    description: "Observation description",
+    ux_note: "Observation ux_notes",
   });
 });
 describe("GET /campaigns/:campaignId/observations", () => {
@@ -89,6 +89,18 @@ describe("GET /campaigns/:campaignId/observations", () => {
       expect.arrayContaining([
         expect.objectContaining({
           name: expect.any(String),
+        }),
+      ])
+    );
+  });
+  it("Should return items with time", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          time: expect.any(Number),
         }),
       ])
     );

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -17,6 +17,14 @@ beforeAll(async () => {
     customer_title: "",
     campaign_pts: 200,
   });
+  await tryber.tables.WpAppqUsecaseMediaObservations.do().insert({
+    id: 1,
+    media_id: 1,
+    name: "name",
+    video_ts: 0,
+    description: "description",
+    ux_note: "ux_notes",
+  });
 });
 describe("GET /campaigns/:campaignId/observations", () => {
   it("Should return 400 if campaign does not exist", async () => {
@@ -57,6 +65,20 @@ describe("GET /campaigns/:campaignId/observations", () => {
     const response = await request(app)
       .get("/campaigns/1/observations")
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
-    expect(response.body).toHaveProperty("items", []);
+    expect(response.body).toHaveProperty("items");
+    expect(response.body.items).toBeInstanceOf(Array);
+  });
+
+  it("Should return items with id", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(Number),
+        }),
+      ])
+    );
   });
 });

--- a/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.spec.ts
@@ -17,14 +17,66 @@ beforeAll(async () => {
     customer_title: "",
     campaign_pts: 200,
   });
-  await tryber.tables.WpAppqUsecaseMediaObservations.do().insert({
-    id: 1,
-    media_id: 1,
-    name: "Observation name",
-    video_ts: 59,
-    description: "Observation description",
-    ux_note: "Observation ux_notes",
-  });
+  await tryber.tables.WpAppqUsecaseMediaObservations.do().insert([
+    {
+      id: 1,
+      media_id: 1,
+      name: "Observation1 name",
+      video_ts: 59,
+      description: "Observation1 description",
+      ux_note: "Observation1 ux_notes",
+    },
+    {
+      id: 2,
+      media_id: 2,
+      name: "Observation2 name",
+      video_ts: 59,
+      description: "Observation2 description",
+      ux_note: "Observation2 ux_notes",
+    },
+  ]);
+  await tryber.tables.WpAppqUserTaskMedia.do().insert([
+    {
+      id: 1,
+      campaign_task_id: 10,
+      user_task_id: 1,
+      tester_id: 1,
+      location: "https://www.youtube.com/@tryber_official",
+    },
+    {
+      id: 2,
+      campaign_task_id: 20,
+      user_task_id: 1,
+      tester_id: 1,
+      location: "https://www.youtube.com/@tryber_official",
+    },
+  ]);
+  await tryber.tables.WpAppqCampaignTask.do().insert([
+    {
+      id: 10,
+      campaign_id: 1,
+      title: "Campaign Task1 title",
+      simple_title: "Campaign Task1 simple_title",
+      content: "Campaign Task1 content",
+      info: "Campaign Task1 info",
+      prefix: "Campaign Task1 prefix",
+      is_required: 1,
+      jf_code: "Campaign Task1 jf_code",
+      jf_text: "Campaign Task1 jf_text",
+    },
+    {
+      id: 20,
+      campaign_id: 2,
+      title: "Campaign Task2 title",
+      simple_title: "Campaign Task2 simple_title",
+      content: "Campaign Task2 content",
+      info: "Campaign Task2 info",
+      prefix: "Campaign Task2 prefix",
+      is_required: 0,
+      jf_code: "Campaign Task2 jf_code",
+      jf_text: "Campaign Task2 jf_text",
+    },
+  ]);
 });
 describe("GET /campaigns/:campaignId/observations", () => {
   it("Should return 400 if campaign does not exist", async () => {
@@ -67,6 +119,14 @@ describe("GET /campaigns/:campaignId/observations", () => {
       .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
     expect(response.body).toHaveProperty("items");
     expect(response.body.items).toBeInstanceOf(Array);
+  });
+
+  it("Should return observations of a specific campaign", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/observations")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    console.log(response.body.items);
+    expect(response.body.items.length).toBe(1);
   });
 
   it("Should return items with id", async () => {

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -1,0 +1,26 @@
+/** OPENAPI-CLASS: get-campaigns-campaign-observations */
+
+import { tryber } from "@src/features/database";
+import OpenapiError from "@src/features/OpenapiError";
+import CampaignRoute from "@src/features/routes/CampaignRoute";
+export default class SingleCampaignRoute extends CampaignRoute<{
+  response: StoplightOperations["get-campaigns-campaign-observations"]["responses"]["200"]["content"]["application/json"];
+  parameters: StoplightOperations["get-campaigns-campaign-observations"]["parameters"]["path"];
+}> {
+  protected async filter(): Promise<boolean> {
+    if (!(await super.filter())) return false;
+
+    if (!this.hasAccessToCampaign(this.cp_id)) {
+      this.setError(403, new OpenapiError("Access denied"));
+      return false;
+    }
+
+    return true;
+  }
+
+  protected async prepare(): Promise<void> {
+    return this.setSuccess(200, {
+      items: [],
+    });
+  }
+}

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -19,62 +19,58 @@ export default class SingleCampaignRoute extends CampaignRoute<{
 
   protected async prepare(): Promise<void> {
     return this.setSuccess(200, {
-      items: await this.getObeservations(),
+      items: await this.getObservations(),
     });
   }
 
-  private async getObeservations() {
-    const obeservations =
-      await tryber.tables.WpAppqUsecaseMediaObservations.do()
-        .select(
-          tryber.ref("id").withSchema("wp_appq_usecase_media_observations"),
-          tryber.ref("name").withSchema("wp_appq_usecase_media_observations"),
-          tryber
-            .ref("video_ts")
-            .withSchema("wp_appq_usecase_media_observations")
-            .as("time"),
-          tryber
-            .ref("id")
-            .withSchema("wp_appq_usecase_cluster")
-            .as("cluster_id"),
-          tryber
-            .ref("title")
-            .withSchema("wp_appq_usecase_cluster")
-            .as("cluster_title"),
-          tryber.ref("id").withSchema("wp_appq_evd_profile").as("tester_id"),
-          tryber.ref("name").withSchema("wp_appq_evd_profile").as("tester_name")
-        )
-        .join(
-          "wp_appq_user_task_media",
-          "wp_appq_usecase_media_observations.media_id",
-          "wp_appq_user_task_media.id"
-        )
-        .join(
-          "wp_appq_campaign_task",
-          "wp_appq_user_task_media.campaign_task_id",
-          "wp_appq_campaign_task.id"
-        )
-        .join(
-          "wp_appq_usecase_cluster",
-          "wp_appq_campaign_task.cluster_id",
-          "wp_appq_usecase_cluster.id"
-        )
-        .join(
-          "wp_appq_evd_profile",
-          "wp_appq_user_task_media.tester_id",
-          "wp_appq_evd_profile.id"
-        )
-        .where("wp_appq_campaign_task.campaign_id", this.cp_id);
-    if (obeservations === undefined) return [];
-    return obeservations.map((obeservation) => ({
-      id: obeservation.id,
-      name: obeservation.name,
-      time: obeservation.time,
+  private async getObservations() {
+    const observations = await tryber.tables.WpAppqUsecaseMediaObservations.do()
+      .select(
+        tryber.ref("id").withSchema("wp_appq_usecase_media_observations"),
+        tryber.ref("name").withSchema("wp_appq_usecase_media_observations"),
+        tryber
+          .ref("video_ts")
+          .withSchema("wp_appq_usecase_media_observations")
+          .as("time"),
+        tryber.ref("id").withSchema("wp_appq_usecase_cluster").as("cluster_id"),
+        tryber
+          .ref("title")
+          .withSchema("wp_appq_usecase_cluster")
+          .as("cluster_title"),
+        tryber.ref("id").withSchema("wp_appq_evd_profile").as("tester_id"),
+        tryber.ref("name").withSchema("wp_appq_evd_profile").as("tester_name")
+      )
+      .join(
+        "wp_appq_user_task_media",
+        "wp_appq_usecase_media_observations.media_id",
+        "wp_appq_user_task_media.id"
+      )
+      .join(
+        "wp_appq_campaign_task",
+        "wp_appq_user_task_media.campaign_task_id",
+        "wp_appq_campaign_task.id"
+      )
+      .join(
+        "wp_appq_usecase_cluster",
+        "wp_appq_campaign_task.cluster_id",
+        "wp_appq_usecase_cluster.id"
+      )
+      .join(
+        "wp_appq_evd_profile",
+        "wp_appq_user_task_media.tester_id",
+        "wp_appq_evd_profile.id"
+      )
+      .where("wp_appq_campaign_task.campaign_id", this.cp_id);
+
+    return observations.map((observation) => ({
+      id: observation.id,
+      name: observation.name,
+      time: observation.time,
       cluster: {
-        id: obeservation.cluster_id,
-        name: obeservation.cluster_title,
+        id: observation.cluster_id,
+        name: observation.cluster_title,
       },
-      tester: { id: obeservation.tester_id, name: obeservation.tester_name },
+      tester: { id: observation.tester_id, name: observation.tester_name },
     }));
   }
 }

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -27,14 +27,15 @@ export default class SingleCampaignRoute extends CampaignRoute<{
     const obeservations =
       await tryber.tables.WpAppqUsecaseMediaObservations.do().select(
         "id",
-        "name"
+        "name",
+        tryber.ref("video_ts").as("time")
       );
     if (obeservations === undefined) return [];
     return obeservations.map((obeservation) => {
       return {
         id: obeservation.id,
         name: obeservation.name,
-        time: 0,
+        time: obeservation.time,
         tester: { id: 0, name: "name" },
         cluster: { id: 0, name: "name" },
       };

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -40,7 +40,9 @@ export default class SingleCampaignRoute extends CampaignRoute<{
           tryber
             .ref("title")
             .withSchema("wp_appq_usecase_cluster")
-            .as("cluster_title")
+            .as("cluster_title"),
+          tryber.ref("id").withSchema("wp_appq_evd_profile").as("tester_id"),
+          tryber.ref("name").withSchema("wp_appq_evd_profile").as("tester_name")
         )
         .join(
           "wp_appq_user_task_media",
@@ -57,6 +59,11 @@ export default class SingleCampaignRoute extends CampaignRoute<{
           "wp_appq_campaign_task.cluster_id",
           "wp_appq_usecase_cluster.id"
         )
+        .join(
+          "wp_appq_evd_profile",
+          "wp_appq_user_task_media.tester_id",
+          "wp_appq_evd_profile.id"
+        )
         .where("wp_appq_campaign_task.campaign_id", this.cp_id);
     if (obeservations === undefined) return [];
     return obeservations.map((obeservation) => ({
@@ -67,7 +74,7 @@ export default class SingleCampaignRoute extends CampaignRoute<{
         id: obeservation.cluster_id,
         name: obeservation.cluster_title,
       },
-      tester: { id: 0, name: "name" },
+      tester: { id: obeservation.tester_id, name: obeservation.tester_name },
     }));
   }
 }

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -32,7 +32,15 @@ export default class SingleCampaignRoute extends CampaignRoute<{
           tryber
             .ref("video_ts")
             .withSchema("wp_appq_usecase_media_observations")
-            .as("time")
+            .as("time"),
+          tryber
+            .ref("id")
+            .withSchema("wp_appq_usecase_cluster")
+            .as("cluster_id"),
+          tryber
+            .ref("title")
+            .withSchema("wp_appq_usecase_cluster")
+            .as("cluster_title")
         )
         .join(
           "wp_appq_user_task_media",
@@ -44,14 +52,22 @@ export default class SingleCampaignRoute extends CampaignRoute<{
           "wp_appq_user_task_media.campaign_task_id",
           "wp_appq_campaign_task.id"
         )
+        .join(
+          "wp_appq_usecase_cluster",
+          "wp_appq_campaign_task.cluster_id",
+          "wp_appq_usecase_cluster.id"
+        )
         .where("wp_appq_campaign_task.campaign_id", this.cp_id);
     if (obeservations === undefined) return [];
     return obeservations.map((obeservation) => ({
       id: obeservation.id,
       name: obeservation.name,
       time: obeservation.time,
+      cluster: {
+        id: obeservation.cluster_id,
+        name: obeservation.cluster_title,
+      },
       tester: { id: 0, name: "name" },
-      cluster: { id: 0, name: "name" },
     }));
   }
 }

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -14,13 +14,29 @@ export default class SingleCampaignRoute extends CampaignRoute<{
       this.setError(403, new OpenapiError("Access denied"));
       return false;
     }
-
     return true;
   }
 
   protected async prepare(): Promise<void> {
     return this.setSuccess(200, {
-      items: [],
+      items: await this.getObeservations(),
+    });
+  }
+
+  private async getObeservations() {
+    const obeservations =
+      await tryber.tables.WpAppqUsecaseMediaObservations.do()
+        .select("id")
+        .where({ id: this.cp_id });
+    if (obeservations === undefined) return [];
+    return obeservations.map((obeservation) => {
+      return {
+        id: obeservation.id,
+        name: "name",
+        time: 0,
+        tester: { id: 0, name: "name" },
+        cluster: { id: 0, name: "name" },
+      };
     });
   }
 }

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -25,14 +25,15 @@ export default class SingleCampaignRoute extends CampaignRoute<{
 
   private async getObeservations() {
     const obeservations =
-      await tryber.tables.WpAppqUsecaseMediaObservations.do()
-        .select("id")
-        .where({ id: this.cp_id });
+      await tryber.tables.WpAppqUsecaseMediaObservations.do().select(
+        "id",
+        "name"
+      );
     if (obeservations === undefined) return [];
     return obeservations.map((obeservation) => {
       return {
         id: obeservation.id,
-        name: "name",
+        name: obeservation.name,
         time: 0,
         tester: { id: 0, name: "name" },
         cluster: { id: 0, name: "name" },

--- a/src/routes/campaigns/campaignId/observations/_get/index.ts
+++ b/src/routes/campaigns/campaignId/observations/_get/index.ts
@@ -25,20 +25,33 @@ export default class SingleCampaignRoute extends CampaignRoute<{
 
   private async getObeservations() {
     const obeservations =
-      await tryber.tables.WpAppqUsecaseMediaObservations.do().select(
-        "id",
-        "name",
-        tryber.ref("video_ts").as("time")
-      );
+      await tryber.tables.WpAppqUsecaseMediaObservations.do()
+        .select(
+          tryber.ref("id").withSchema("wp_appq_usecase_media_observations"),
+          tryber.ref("name").withSchema("wp_appq_usecase_media_observations"),
+          tryber
+            .ref("video_ts")
+            .withSchema("wp_appq_usecase_media_observations")
+            .as("time")
+        )
+        .join(
+          "wp_appq_user_task_media",
+          "wp_appq_usecase_media_observations.media_id",
+          "wp_appq_user_task_media.id"
+        )
+        .join(
+          "wp_appq_campaign_task",
+          "wp_appq_user_task_media.campaign_task_id",
+          "wp_appq_campaign_task.id"
+        )
+        .where("wp_appq_campaign_task.campaign_id", this.cp_id);
     if (obeservations === undefined) return [];
-    return obeservations.map((obeservation) => {
-      return {
-        id: obeservation.id,
-        name: obeservation.name,
-        time: obeservation.time,
-        tester: { id: 0, name: "name" },
-        cluster: { id: 0, name: "name" },
-      };
-    });
+    return obeservations.map((obeservation) => ({
+      id: obeservation.id,
+      name: obeservation.name,
+      time: obeservation.time,
+      tester: { id: 0, name: "name" },
+      cluster: { id: 0, name: "name" },
+    }));
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1642,6 +1642,9 @@ export interface operations {
         /** A campaign id */
         campaign: string;
       };
+      query: {
+        filterBy?: unknown;
+      };
     };
     responses: {
       /** A UseCase linked with the Campaign */


### PR DESCRIPTION
 - GET /campaigns/:campaignId/observations
    ✓ Should return 400 if campaign does not exist
    ✓ Should return 403 if the user does not have permission
    ✓ Should return 200 if the user have olp permission on CP
    ✓ Should return 200 if the user have olp permission on all CPs
    ✓ Should return 200 if the user is admin
    ✓ Should return items array
    ✓ Should return observations of a specific campaign
    ✓ Should return items with id as number
    ✓ Should return items with id
    ✓ Should return items with name as string
    ✓ Should return items with name
    ✓ Should return items with time as number
    ✓ Should return items with time
    ✓ Should return items with cluster as id number and name string
    ✓ Should return items with cluster
    ✓ Should return items with tester as id number and name string
    ✓ Should return items with tester
 - GET /campaigns/:campaignId/observations - there are no observation
    ✓ Should return items array
    ✓ Should return items as empty array if there are no obeservations