### PR TITLE
TID-and-RID-in-mail-payment-object

### DIFF
--- a/src/routes/users/me/payments/_post/index.ts
+++ b/src/routes/users/me/payments/_post/index.ts
@@ -24,6 +24,7 @@ export default class Route extends UserRoute<{
         fiscal_id: string;
       }
     | undefined;
+  private requestId: number = 0;
 
   protected async init() {
     await super.init();
@@ -109,6 +110,7 @@ export default class Route extends UserRoute<{
 
   protected async prepare() {
     const { requestId } = await this.createRequest();
+    this.requestId = requestId;
 
     await this.updatePayments(requestId);
 
@@ -251,13 +253,19 @@ export default class Route extends UserRoute<{
 
   private getSubject() {
     if (this.fiscalProfile.fiscal_category_name === "witholding-extra") {
-      return `[Tryber] T${this.getTesterId()} - Crea la tua ritenuta d'acconto con questi dati`;
+      return `[Tryber] T${this.getTesterId()} - Crea la tua ritenuta d'acconto con questi dati | R${
+        this.requestId
+      }`;
     } else if (
       ["vat", "company"].includes(this.fiscalProfile.fiscal_category_name)
     ) {
-      return `[Tryber] T${this.getTesterId()} - Crea la tua fattura con questi dati`;
+      return `[Tryber] T${this.getTesterId()} - Crea la tua fattura con questi dati | R${
+        this.requestId
+      }`;
     } else {
-      return `[Tryber] T${this.getTesterId()} - Payout Request`;
+      return `[Tryber] T${this.getTesterId()} - Payout Request | R${
+        this.requestId
+      }`;
     }
   }
 

--- a/src/routes/users/me/payments/_post/index.ts
+++ b/src/routes/users/me/payments/_post/index.ts
@@ -251,7 +251,7 @@ export default class Route extends UserRoute<{
 
   private getSubject() {
     if (this.fiscalProfile.fiscal_category_name === "witholding-extra") {
-      return "[Tryber] Crea la tua ritenuta d'acconto con questi dati";
+      return `[Tryber] T${this.getTesterId()} - Crea la tua ritenuta d'acconto con questi dati`;
     } else if (
       ["vat", "company"].includes(this.fiscalProfile.fiscal_category_name)
     ) {

--- a/src/routes/users/me/payments/_post/index.ts
+++ b/src/routes/users/me/payments/_post/index.ts
@@ -255,7 +255,7 @@ export default class Route extends UserRoute<{
     } else if (
       ["vat", "company"].includes(this.fiscalProfile.fiscal_category_name)
     ) {
-      return "[Tryber] Crea la tua fattura con questi dati";
+      return `[Tryber] T${this.getTesterId()} - Crea la tua fattura con questi dati`;
     } else {
       return `[Tryber] T${this.getTesterId()} - Payout Request`;
     }

--- a/src/routes/users/me/payments/_post/index.ts
+++ b/src/routes/users/me/payments/_post/index.ts
@@ -257,7 +257,7 @@ export default class Route extends UserRoute<{
     ) {
       return "[Tryber] Crea la tua fattura con questi dati";
     } else {
-      return "[Tryber] Payout Request";
+      return `[Tryber] T${this.getTesterId()} - Payout Request`;
     }
   }
 

--- a/src/routes/users/me/payments/_post/mail.spec.ts
+++ b/src/routes/users/me/payments/_post/mail.spec.ts
@@ -230,6 +230,11 @@ describe("POST /users/me/payments", () => {
           },
         })
         .set("Authorization", "Bearer tester");
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
       expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
       expect(mockedSendgrid.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -238,7 +243,7 @@ describe("POST /users/me/payments", () => {
             name: "Tryber",
           },
           html: expect.stringContaining("PAYMENT_REQUESTED_EMAIL_BODY"),
-          subject: "[Tryber] T1 - Payout Request",
+          subject: `[Tryber] T1 - Payout Request | R${requestData?.id}`,
           categories: ["Test"],
         })
       );
@@ -396,6 +401,31 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with RequestID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      expect(mockedSendgrid.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: expect.stringContaining(`R${requestData?.id}`),
+        })
+      );
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("POST /users/me/payments/ - fiscal profile 2", () => {
@@ -426,6 +456,11 @@ describe("POST /users/me/payments", () => {
           },
         })
         .set("Authorization", "Bearer tester");
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
       expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
       expect(mockedSendgrid.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -436,8 +471,7 @@ describe("POST /users/me/payments", () => {
           html: expect.stringContaining(
             "PAYMENT_INVOICE_RECAP_EMAIL_WITHOLDING_EXTRA_BODY"
           ),
-          subject:
-            "[Tryber] T1 - Crea la tua ritenuta d'acconto con questi dati",
+          subject: `[Tryber] T1 - Crea la tua ritenuta d'acconto con questi dati | R${requestData?.id}`,
           categories: ["Test"],
         })
       );
@@ -633,7 +667,6 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
-
     it("Should add an email to cc", async () => {
       const response = await request(app)
         .post("/users/me/payments")
@@ -672,6 +705,32 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with RequestID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      if (requestData)
+        expect(mockedSendgrid.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            subject: expect.stringContaining(`R${requestData.id}`),
+          })
+        );
+      expect(response.status).toBe(200);
+    });
   });
   describe("POST /users/me/payments/ - fiscal profile 3", () => {
     beforeEach(async () => {
@@ -701,6 +760,11 @@ describe("POST /users/me/payments", () => {
           },
         })
         .set("Authorization", "Bearer tester");
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
       expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
       expect(mockedSendgrid.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -709,7 +773,7 @@ describe("POST /users/me/payments", () => {
             name: "Tryber",
           },
           html: expect.stringContaining("PAYMENT_INVOICE_RECAP_EMAIL_VAT_BODY"),
-          subject: "[Tryber] T1 - Crea la tua fattura con questi dati",
+          subject: `[Tryber] T1 - Crea la tua fattura con questi dati | R${requestData?.id}`,
           categories: ["Test"],
         })
       );
@@ -905,6 +969,32 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with RequestID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      if (requestData)
+        expect(mockedSendgrid.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            subject: expect.stringContaining(`R${requestData.id}`),
+          })
+        );
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("POST /users/me/payments/ - fiscal profile 4", () => {
@@ -942,7 +1032,7 @@ describe("POST /users/me/payments", () => {
             name: "Tryber",
           },
           html: expect.stringContaining("PAYMENT_REQUESTED_EMAIL_BODY"),
-          subject: "[Tryber] T1 - Payout Request",
+          subject: "[Tryber] T1 - Payout Request | R37",
           categories: ["Test"],
         })
       );
@@ -1081,6 +1171,32 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with RequestID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      if (requestData)
+        expect(mockedSendgrid.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            subject: expect.stringContaining(`R${requestData.id}`),
+          })
+        );
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("POST /users/me/payments/ - fiscal profile 5", () => {
@@ -1121,7 +1237,7 @@ describe("POST /users/me/payments", () => {
           html: expect.stringContaining(
             "PAYMENT_INVOICE_RECAP_EMAIL_COMPANY_BODY"
           ),
-          subject: "[Tryber] T1 - Crea la tua fattura con questi dati",
+          subject: "[Tryber] T1 - Crea la tua fattura con questi dati | R46",
           categories: ["Test"],
         })
       );
@@ -1334,6 +1450,32 @@ describe("POST /users/me/payments", () => {
           subject: expect.stringContaining("T1"),
         })
       );
+      expect(response.status).toBe(200);
+    });
+    it("Should send an email with RequestID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+
+      const requestData = await tryber.tables.WpAppqPaymentRequest.do()
+        .select("id")
+        .where({ tester_id: 1 })
+        .andWhere({ is_paid: 0 })
+        .first();
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      if (requestData)
+        expect(mockedSendgrid.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            subject: expect.stringContaining(`R${requestData.id}`),
+          })
+        );
       expect(response.status).toBe(200);
     });
   });

--- a/src/routes/users/me/payments/_post/mail.spec.ts
+++ b/src/routes/users/me/payments/_post/mail.spec.ts
@@ -652,6 +652,25 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with TID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      expect(mockedSendgrid.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: expect.stringContaining("T1"),
+        })
+      );
+      expect(response.status).toBe(200);
+    });
   });
   describe("POST /users/me/payments/ - fiscal profile 3", () => {
     beforeEach(async () => {

--- a/src/routes/users/me/payments/_post/mail.spec.ts
+++ b/src/routes/users/me/payments/_post/mail.spec.ts
@@ -377,6 +377,25 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with TID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      expect(mockedSendgrid.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: expect.stringContaining("T1"),
+        })
+      );
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("POST /users/me/payments/ - fiscal profile 2", () => {

--- a/src/routes/users/me/payments/_post/mail.spec.ts
+++ b/src/routes/users/me/payments/_post/mail.spec.ts
@@ -238,7 +238,7 @@ describe("POST /users/me/payments", () => {
             name: "Tryber",
           },
           html: expect.stringContaining("PAYMENT_REQUESTED_EMAIL_BODY"),
-          subject: "[Tryber] Payout Request",
+          subject: "[Tryber] T1 - Payout Request",
           categories: ["Test"],
         })
       );
@@ -436,7 +436,8 @@ describe("POST /users/me/payments", () => {
           html: expect.stringContaining(
             "PAYMENT_INVOICE_RECAP_EMAIL_WITHOLDING_EXTRA_BODY"
           ),
-          subject: "[Tryber] Crea la tua ritenuta d'acconto con questi dati",
+          subject:
+            "[Tryber] T1 - Crea la tua ritenuta d'acconto con questi dati",
           categories: ["Test"],
         })
       );
@@ -708,7 +709,7 @@ describe("POST /users/me/payments", () => {
             name: "Tryber",
           },
           html: expect.stringContaining("PAYMENT_INVOICE_RECAP_EMAIL_VAT_BODY"),
-          subject: "[Tryber] Crea la tua fattura con questi dati",
+          subject: "[Tryber] T1 - Crea la tua fattura con questi dati",
           categories: ["Test"],
         })
       );
@@ -866,7 +867,6 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
-
     it("Should add an email to cc", async () => {
       const response = await request(app)
         .post("/users/me/payments")
@@ -882,6 +882,25 @@ describe("POST /users/me/payments", () => {
       expect(mockedSendgrid.send).toHaveBeenCalledWith(
         expect.objectContaining({
           cc: "it+administration@unguess.io",
+        })
+      );
+      expect(response.status).toBe(200);
+    });
+    it("Should send an email with TID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      expect(mockedSendgrid.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: expect.stringContaining("T1"),
         })
       );
       expect(response.status).toBe(200);
@@ -923,7 +942,7 @@ describe("POST /users/me/payments", () => {
             name: "Tryber",
           },
           html: expect.stringContaining("PAYMENT_REQUESTED_EMAIL_BODY"),
-          subject: "[Tryber] Payout Request",
+          subject: "[Tryber] T1 - Payout Request",
           categories: ["Test"],
         })
       );
@@ -1043,6 +1062,25 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
+    it("Should send an email with TID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      expect(mockedSendgrid.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: expect.stringContaining("T1"),
+        })
+      );
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("POST /users/me/payments/ - fiscal profile 5", () => {
@@ -1083,7 +1121,7 @@ describe("POST /users/me/payments", () => {
           html: expect.stringContaining(
             "PAYMENT_INVOICE_RECAP_EMAIL_COMPANY_BODY"
           ),
-          subject: "[Tryber] Crea la tua fattura con questi dati",
+          subject: "[Tryber] T1 - Crea la tua fattura con questi dati",
           categories: ["Test"],
         })
       );
@@ -1260,7 +1298,6 @@ describe("POST /users/me/payments", () => {
       );
       expect(response.status).toBe(200);
     });
-
     it("Should add an email to cc", async () => {
       const response = await request(app)
         .post("/users/me/payments")
@@ -1276,6 +1313,25 @@ describe("POST /users/me/payments", () => {
       expect(mockedSendgrid.send).toHaveBeenCalledWith(
         expect.objectContaining({
           cc: "it+administration@unguess.io",
+        })
+      );
+      expect(response.status).toBe(200);
+    });
+    it("Should send an email with TID in Subject", async () => {
+      const response = await request(app)
+        .post("/users/me/payments")
+        .send({
+          method: {
+            type: "iban",
+            iban: "IT75T0300203280284975661141",
+            accountHolderName: "John Doe",
+          },
+        })
+        .set("Authorization", "Bearer tester");
+      expect(mockedSendgrid.send).toHaveBeenCalledTimes(1);
+      expect(mockedSendgrid.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: expect.stringContaining("T1"),
         })
       );
       expect(response.status).toBe(200);


### PR DESCRIPTION
** Expectance **

- The mail object when is requested a new payment should contain TID (testerId) and RID (paymentRequestId)
- The mail object when is requested a new payment should respect the following format: [Tryber] TID - {message} | RID