### PR TITLE
Update Campaign Class and API Bug Type

### DIFF
--- a/src/features/class/Campaign.ts
+++ b/src/features/class/Campaign.ts
@@ -105,36 +105,30 @@ class Campaign {
         .select("bug_type_id")
         .where({ campaign_id: this.id })
     ).map((c) => c.bug_type_id);
-    const enabledTypes = await getEnabledTypes();
+    const allTypes = await getAllTypes();
     // If no custom bug types are set, return all enabled types
     if (!customTypes.length) {
       return {
-        valid: enabledTypes,
+        valid: allTypes.filter((t) => t.is_enabled),
         invalid: [],
       };
     }
     // Else, return the custom bug types (also disabled types if selected)
-    const allTypes = await getAllTypes();
     return {
       valid: allTypes.filter((s) => customTypes.includes(s.id)),
-      invalid: enabledTypes.filter((s) => !customTypes.includes(s.id)),
+      invalid: allTypes.filter(
+        (s) => s.is_enabled && !customTypes.includes(s.id)
+      ),
     };
 
-    async function getEnabledTypes(): Promise<{ id: number; name: string }[]> {
+    async function getAllTypes() {
       return (
-        await tryber.tables.WpAppqEvdBugType.do()
-          .select(["id", "name"])
-          .where({ is_enabled: 1 })
-      ).map((s: typeof enabledTypes[0]) => ({
-        ...s,
-        name: s.name.toUpperCase(),
-      }));
-    }
-
-    async function getAllTypes(): Promise<{ id: number; name: string }[]> {
-      return (
-        await tryber.tables.WpAppqEvdBugType.do().select(["id", "name"])
-      ).map((s: typeof enabledTypes[0]) => ({
+        await tryber.tables.WpAppqEvdBugType.do().select([
+          "id",
+          "name",
+          "is_enabled",
+        ])
+      ).map((s) => ({
         ...s,
         name: s.name.toUpperCase(),
       }));

--- a/src/features/class/Campaign.ts
+++ b/src/features/class/Campaign.ts
@@ -105,55 +105,37 @@ class Campaign {
         .select("bug_type_id")
         .where({ campaign_id: this.id })
     ).map((c) => c.bug_type_id);
-    const types = await getTypes();
+    const enabledTypes = await getEnabledTypes();
     if (!customTypes.length) {
       return {
-        valid: types.filter(isValidBugType),
+        valid: enabledTypes,
         invalid: [],
       };
     }
+    const allTypes = await getAllTypes();
     return {
-      valid: types
-        .filter((s) => customTypes.includes(s.id))
-        .filter(isValidBugType),
-      invalid: types
-        .filter((s) => !customTypes.includes(s.id))
-        .filter(isValidBugType),
+      valid: allTypes.filter((s) => customTypes.includes(s.id)),
+      invalid: enabledTypes.filter((s) => !customTypes.includes(s.id)),
     };
 
-    async function getTypes(): Promise<{ id: number; name: string }[]> {
+    async function getEnabledTypes(): Promise<{ id: number; name: string }[]> {
       return (
         await tryber.tables.WpAppqEvdBugType.do()
           .select(["id", "name"])
           .where({ is_enabled: 1 })
-      ).map((s: typeof types[0]) => ({
+      ).map((s: typeof enabledTypes[0]) => ({
         ...s,
         name: s.name.toUpperCase(),
       }));
     }
 
-    function isValidBugType(item: { id: number; name: string }): item is {
-      id: number;
-      name:
-        | "CRASH"
-        | "GRAPHIC"
-        | "MALFUNCTION"
-        | "OTHER"
-        | "PERFORMANCE"
-        | "SECURITY"
-        | "TYPO"
-        | "USABILITY";
-    } {
-      return [
-        "CRASH",
-        "GRAPHIC",
-        "MALFUNCTION",
-        "OTHER",
-        "PERFORMANCE",
-        "SECURITY",
-        "TYPO",
-        "USABILITY",
-      ].includes(item.name);
+    async function getAllTypes(): Promise<{ id: number; name: string }[]> {
+      return (
+        await tryber.tables.WpAppqEvdBugType.do().select(["id", "name"])
+      ).map((s: typeof enabledTypes[0]) => ({
+        ...s,
+        name: s.name.toUpperCase(),
+      }));
     }
   }
 

--- a/src/features/class/Campaign.ts
+++ b/src/features/class/Campaign.ts
@@ -106,12 +106,14 @@ class Campaign {
         .where({ campaign_id: this.id })
     ).map((c) => c.bug_type_id);
     const enabledTypes = await getEnabledTypes();
+    // If no custom bug types are set, return all enabled types
     if (!customTypes.length) {
       return {
         valid: enabledTypes,
         invalid: [],
       };
     }
+    // Else, return the custom bug types (also disabled types if selected)
     const allTypes = await getAllTypes();
     return {
       valid: allTypes.filter((s) => customTypes.includes(s.id)),

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -6666,15 +6666,6 @@ paths:
                       - ALWAYS
                   type:
                     type: string
-                    enum:
-                      - CRASH
-                      - GRAPHIC
-                      - MALFUNCTION
-                      - OTHER
-                      - PERFORMANCE
-                      - SECURITY
-                      - TYPO
-                      - USABILITY
                   notes:
                     type: string
                   usecase:
@@ -6764,15 +6755,6 @@ paths:
                     - ALWAYS
                 type:
                   type: string
-                  enum:
-                    - CRASH
-                    - GRAPHIC
-                    - MALFUNCTION
-                    - OTHER
-                    - PERFORMANCE
-                    - SECURITY
-                    - TYPO
-                    - USABILITY
                 notes:
                   type: string
                 lastSeen:

--- a/src/routes/users/me/campaigns/campaignId/_get/index.spec.ts
+++ b/src/routes/users/me/campaigns/campaignId/_get/index.spec.ts
@@ -111,11 +111,15 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - custom bug types set for
     await tryber.tables.WpAppqAdditionalBugTypes.do().insert([
       {
         campaign_id: 2,
-        bug_type_id: 2,
+        bug_type_id: 2, // Crash - enabled
       },
       {
         campaign_id: 1,
-        bug_type_id: 1,
+        bug_type_id: 1, // Typo - enabled
+      },
+      {
+        campaign_id: 1,
+        bug_type_id: 3, // Atomic - disabled
       },
     ]);
   });
@@ -127,7 +131,17 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - custom bug types set for
       .get("/users/me/campaigns/1")
       .set("Authorization", "Bearer tester");
     expect(response.body).toMatchObject({
-      bugTypes: { valid: ["TYPO"], invalid: ["CRASH"] },
+      bugTypes: { valid: ["TYPO", "ATOMIC"], invalid: ["CRASH"] },
+    });
+  });
+  it("Should return selected bug types also if type are disabled", async () => {
+    const response = await request(app)
+      .get("/users/me/campaigns/1")
+      .set("Authorization", "Bearer tester");
+    expect(response.body).toMatchObject({
+      bugTypes: {
+        valid: expect.arrayContaining(["ATOMIC"]),
+      },
     });
   });
 });

--- a/src/routes/users/me/campaigns/campaignId/_get/index.spec.ts
+++ b/src/routes/users/me/campaigns/campaignId/_get/index.spec.ts
@@ -108,6 +108,11 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - custom severities set fo
 describe("Route GET /users/me/campaigns/{campaignId}/ - custom bug types set for a specific CP", () => {
   useBasicData();
   beforeAll(async () => {
+    await tryber.tables.WpAppqEvdBugType.do().insert([
+      { id: 30, name: "Corrupted", is_enabled: 1 },
+      { id: 40, name: "Persistent", is_enabled: 0 },
+    ]);
+
     await tryber.tables.WpAppqAdditionalBugTypes.do().insert([
       {
         campaign_id: 2,
@@ -121,6 +126,10 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - custom bug types set for
         campaign_id: 1,
         bug_type_id: 3, // Atomic - disabled
       },
+      {
+        campaign_id: 1,
+        bug_type_id: 30, // Corrupted - enabled
+      },
     ]);
   });
   afterAll(async () => {
@@ -131,7 +140,7 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - custom bug types set for
       .get("/users/me/campaigns/1")
       .set("Authorization", "Bearer tester");
     expect(response.body).toMatchObject({
-      bugTypes: { valid: ["TYPO", "ATOMIC"], invalid: ["CRASH"] },
+      bugTypes: { valid: ["TYPO", "ATOMIC", "CORRUPTED"], invalid: ["CRASH"] },
     });
   });
   it("Should return selected bug types also if type are disabled", async () => {
@@ -141,6 +150,41 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - custom bug types set for
     expect(response.body).toMatchObject({
       bugTypes: {
         valid: expect.arrayContaining(["ATOMIC"]),
+      },
+    });
+  });
+  it("Should return not-standard (enabled  and disabled) custom bug TYPE as valid", async () => {
+    // insert not-standard bug type
+    // standard bug type: CRASH, GRAPHIC, MALFUNCTION, OTHER, PERFORMANCE, SECURITY, TYPO, USABILITY
+    const standard = [
+      "CRASH",
+      "GRAPHIC",
+      "MALFUNCTION",
+      "OTHER",
+      "PERFORMANCE",
+      "SECURITY",
+      "TYPO",
+      "USABILITY",
+    ];
+    const noStandardCustomTypes = (
+      await tryber.tables.WpAppqEvdBugType.do()
+        .select("name")
+        .join(
+          "wp_appq_additional_bug_types",
+          "wp_appq_evd_bug_type.id",
+          "wp_appq_additional_bug_types.bug_type_id"
+        )
+        .where("wp_appq_additional_bug_types.campaign_id", 1)
+    )
+      .map((type) => type.name.toUpperCase())
+      .filter((type) => !standard.includes(type));
+
+    const response = await request(app)
+      .get("/users/me/campaigns/1")
+      .set("Authorization", "Bearer tester");
+    expect(response.body).toMatchObject({
+      bugTypes: {
+        valid: expect.arrayContaining(noStandardCustomTypes),
       },
     });
   });

--- a/src/routes/users/me/campaigns/campaignId/bugs/_post/index.spec.ts
+++ b/src/routes/users/me/campaigns/campaignId/bugs/_post/index.spec.ts
@@ -42,8 +42,10 @@ jest.mock("@src/features/getMimetypeFromS3");
 describe("Route POST a bug to a specific campaign", () => {
   useBasicData();
   beforeEach(async () => {
-    await tryber.tables.WpAppqEvdSeverity.do().insert({ id: 1, name: "LOW" });
-    await tryber.tables.WpAppqEvdSeverity.do().insert({ id: 2, name: "HIGH" });
+    await tryber.tables.WpAppqEvdSeverity.do().insert([
+      { id: 1, name: "LOW" },
+      { id: 2, name: "HIGH" },
+    ]);
     await tryber.tables.WpAppqEvdBugReplicability.do().insert({
       id: 1,
       name: "Once",
@@ -52,13 +54,10 @@ describe("Route POST a bug to a specific campaign", () => {
       id: 2,
       name: "Sometimes",
     });
-    await tryber.tables.WpAppqEvdBugType.do().insert({ id: 1, name: "Crash" });
-    await tryber.tables.WpAppqEvdBugType.do().insert({ id: 2, name: "Typo" });
-    await tryber.tables.WpAppqEvdBugType.do().insert({
-      id: 3,
-      name: "Other",
-      is_enabled: 0,
-    });
+    await tryber.tables.WpAppqEvdBugType.do().insert([
+      { id: 1, name: "Crash", is_enabled: 1 },
+      { id: 3, name: "Other", is_enabled: 0 },
+    ]);
     await tryber.tables.WpAppqEvdPlatform.do().insert({
       id: 1,
       name: "Android",
@@ -72,69 +71,73 @@ describe("Route POST a bug to a specific campaign", () => {
       main_release: 1,
       version_family: 1,
     });
-    await tryber.tables.WpCrowdAppqDevice.do().insert({
-      id: 1,
-      enabled: 1,
-      id_profile: 1,
-      manufacturer: "Acer",
-      model: "Iconia A1",
-      platform_id: 1,
-      os_version_id: 798,
-      form_factor: "Tablet",
-      source_id: 950,
-    });
-    await tryber.tables.WpCrowdAppqDevice.do().insert({
-      id: 2,
-      enabled: 1,
-      id_profile: 1,
-      manufacturer: "Acer",
-      model: "Iconia A1",
-      platform_id: 1,
-      os_version_id: 798,
-      form_factor: "Tablet",
-      source_id: 950,
-    });
-    await tryber.tables.WpCrowdAppqDevice.do().insert({
-      id: 3,
-      enabled: 1,
-      id_profile: 1,
-      manufacturer: "Acer",
-      model: "Iconia A1",
-      platform_id: 1,
-      os_version_id: 798,
-      form_factor: "PC",
-      source_id: 950,
-      pc_type: "Notebook",
-    });
-    await tryber.tables.WpAppqCampaignAdditionalFields.do().insert({
-      id: 1,
-      slug: "codice-cliente",
-      type: "regex",
-      title: "Codice cliente",
-      error_message: "",
-      validation: "^[0-9a-zA-Z]+$",
-      cp_id: 1,
-    });
-    await tryber.tables.WpAppqCampaignAdditionalFields.do().insert({
-      id: 2,
-      slug: "nome-banca",
-      type: "select",
-      validation: "intesa; etruria; sanpaolo",
-      title: "Nome banca",
-      error_message: "",
-      cp_id: 1,
-    });
+    await tryber.tables.WpCrowdAppqDevice.do().insert([
+      {
+        id: 1,
+        enabled: 1,
+        id_profile: 1,
+        manufacturer: "Acer",
+        model: "Iconia A1",
+        platform_id: 1,
+        os_version_id: 798,
+        form_factor: "Tablet",
+        source_id: 950,
+      },
+      {
+        id: 2,
+        enabled: 1,
+        id_profile: 1,
+        manufacturer: "Acer",
+        model: "Iconia A1",
+        platform_id: 1,
+        os_version_id: 798,
+        form_factor: "Tablet",
+        source_id: 950,
+      },
+      {
+        id: 3,
+        enabled: 1,
+        id_profile: 1,
+        manufacturer: "Acer",
+        model: "Iconia A1",
+        platform_id: 1,
+        os_version_id: 798,
+        form_factor: "PC",
+        source_id: 950,
+        pc_type: "Notebook",
+      },
+    ]);
+    await tryber.tables.WpAppqCampaignAdditionalFields.do().insert([
+      {
+        id: 1,
+        slug: "codice-cliente",
+        type: "regex",
+        title: "Codice cliente",
+        error_message: "",
+        validation: "^[0-9a-zA-Z]+$",
+        cp_id: 1,
+      },
+      {
+        id: 2,
+        slug: "nome-banca",
+        type: "select",
+        validation: "intesa; etruria; sanpaolo",
+        title: "Nome banca",
+        error_message: "",
+        cp_id: 1,
+      },
+    ]);
   });
   afterEach(async () => {
     await tryber.tables.WpAppqEvdSeverity.do().delete();
+    await tryber.tables.WpAppqAdditionalBugSeverities.do().delete();
     await tryber.tables.WpAppqEvdBugReplicability.do().delete();
+    await tryber.tables.WpAppqAdditionalBugReplicabilities.do().delete();
     await tryber.tables.WpAppqEvdBugType.do().delete();
+    await tryber.tables.WpAppqAdditionalBugTypes.do().delete();
     await tryber.tables.WpAppqEvdPlatform.do().delete();
     await tryber.tables.WpAppqOs.do().delete();
     await tryber.tables.WpCrowdAppqDevice.do().delete();
-    await tryber.tables.WpAppqAdditionalBugSeverities.do().delete();
-    await tryber.tables.WpAppqAdditionalBugReplicabilities.do().delete();
-    await tryber.tables.WpAppqAdditionalBugTypes.do().delete();
     await tryber.tables.WpAppqEvdBug.do().delete();
     await tryber.tables.WpAppqEvdBugMedia.do().delete();
     await tryber.tables.WpCrowdAppqDevice.do().delete();
@@ -182,7 +185,6 @@ describe("Route POST a bug to a specific campaign", () => {
       message: `Usecase 100 not found for CP1.`,
     });
   });
-
   it("Should answer 403 if a user sends a bug to a usecase for another group", async () => {
     const response = await request(app)
       .post("/users/me/campaigns/4/bugs")
@@ -195,7 +197,6 @@ describe("Route POST a bug to a specific campaign", () => {
       message: `Usecase 6 not found for CP4.`,
     });
   });
-
   it("Should answer 200 if a user sends a usecase that has all groups", async () => {
     const response = await request(app)
       .post("/users/me/campaigns/4/bugs")
@@ -203,7 +204,6 @@ describe("Route POST a bug to a specific campaign", () => {
       .send({ ...bug, usecase: 7 });
     expect(response.status).toBe(200);
   });
-
   it("Should answer 200 if a user sends a lastSeenDate with another timezone", async () => {
     const response = await request(app)
       .post("/users/me/campaigns/4/bugs")
@@ -211,7 +211,6 @@ describe("Route POST a bug to a specific campaign", () => {
       .send({ ...bug, lastSeen: "2023-03-16T07:56:16.000-03:00", usecase: 7 });
     expect(response.status).toBe(200);
   });
-  //
   it("Should answer 403 if a user sends a bug with a device that's not the candidate one", async () => {
     const response = await request(app)
       .post("/users/me/campaigns/1/bugs")
@@ -379,6 +378,46 @@ describe("Route POST a bug to a specific campaign", () => {
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty("type", "CRASH");
   });
+  it("Should return 200 if send an existent (and enabled) bug TYPE on wp_appq_evd_bug_type", async () => {
+    const bugTypes = (
+      await tryber.tables.WpAppqEvdBugType.do()
+        .select("name")
+        .where({ is_enabled: 1 })
+    ).map((type) => type.name);
+
+    for (const bugType of bugTypes) {
+      const response = await request(app)
+        .post("/users/me/campaigns/1/bugs")
+        .set("authorization", "Bearer tester")
+        .send({ ...bug, type: bugType.toUpperCase() });
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("type", bugType.toUpperCase());
+    }
+  });
+  it("Should return 200 if send a not-standard (and enabled) bug TYPE on wp_appq_evd_bug_type", async () => {
+    // insert not-standard bug type
+    // standard bug type: CRASH, GRAPHIC, MALFUNCTION, OTHER, PERFORMANCE, SECURITY, TYPO, USABILITY
+    await tryber.tables.WpAppqEvdBugType.do().insert([
+      { name: "Corrupted", is_enabled: 1 },
+      { name: "Persistent", is_enabled: 1 },
+      { name: "Supersecurity", is_enabled: 1 },
+    ]);
+    const bugTypes = (
+      await tryber.tables.WpAppqEvdBugType.do()
+        .select("name")
+        .where({ is_enabled: 1 })
+    ).map((type) => type.name);
+
+    for (const bugType of bugTypes) {
+      const response = await request(app)
+        .post("/users/me/campaigns/1/bugs")
+        .set("authorization", "Bearer tester")
+        .send({ ...bug, type: bugType.toUpperCase() });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("type", bugType.toUpperCase());
+    }
+  });
   it("Should update INTERNALID if a user sends a valid bug", async () => {
     const response = await request(app)
       .post("/users/me/campaigns/1/bugs")
@@ -465,23 +504,26 @@ describe("Route POST a bug to a specific campaign", () => {
     ]);
   });
 });
-
 describe("Route POST a bug to a specific campaign - with custom type", () => {
   useBasicData();
   beforeEach(async () => {
-    await tryber.tables.WpAppqEvdSeverity.do().insert({ id: 1, name: "LOW" });
-    await tryber.tables.WpAppqEvdSeverity.do().insert({ id: 2, name: "HIGH" });
+    await tryber.tables.WpAppqEvdSeverity.do().insert([
+      { id: 1, name: "LOW" },
+      { id: 2, name: "HIGH" },
+    ]);
     await tryber.tables.WpAppqEvdBugReplicability.do().insert({
       id: 1,
       name: "Once",
     });
-    await tryber.tables.WpAppqEvdBugType.do().insert({ id: 1, name: "Crash" });
-    await tryber.tables.WpAppqEvdBugType.do().insert({ id: 2, name: "Typo" });
-    await tryber.tables.WpAppqEvdBugType.do().insert({
-      id: 3,
-      name: "Other",
-      is_enabled: 0,
-    });
+    await tryber.tables.WpAppqEvdBugType.do().insert([
+      { id: 1, name: "Crash" },
+      { id: 2, name: "Typo" },
+      { id: 3, name: "Other", is_enabled: 0 },
+    ]);
+    await tryber.tables.WpAppqAdditionalBugTypes.do().insert([
+      { bug_type_id: 3, campaign_id: 1 },
+      { bug_type_id: 1, campaign_id: 1 },
+    ]);
 
     await tryber.tables.WpAppqEvdPlatform.do().insert({
       id: 1,
@@ -496,7 +538,6 @@ describe("Route POST a bug to a specific campaign - with custom type", () => {
       main_release: 1,
       version_family: 1,
     });
-
     await tryber.tables.WpCrowdAppqDevice.do().insert({
       id: 1,
       enabled: 1,
@@ -507,20 +548,6 @@ describe("Route POST a bug to a specific campaign - with custom type", () => {
       os_version_id: 798,
       form_factor: "Tablet",
       source_id: 950,
-    });
-
-    await tryber.tables.WpAppqAdditionalBugSeverities.do().insert({
-      bug_severity_id: 1,
-      campaign_id: 1,
-    });
-
-    await tryber.tables.WpAppqAdditionalBugTypes.do().insert({
-      bug_type_id: 1,
-      campaign_id: 1,
-    });
-    await tryber.tables.WpAppqAdditionalBugTypes.do().insert({
-      bug_type_id: 3,
-      campaign_id: 1,
     });
   });
   afterEach(async () => {
@@ -549,7 +576,8 @@ describe("Route POST a bug to a specific campaign - with custom type", () => {
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty("type", "CRASH");
   });
-  it("Should answer 403 if a user sends a unaccepted bug-type on CP", async () => {
+  it("Should answer 403 if a user sends a non-existent bug-type on CP", async () => {
+    // non-existent bug type means that the bug type is not on wp_appq_additional_bug_types neither on wp_appq_evd_bug_type
     const response = await request(app)
       .post("/users/me/campaigns/1/bugs")
       .set("authorization", "Bearer tester")
@@ -561,8 +589,18 @@ describe("Route POST a bug to a specific campaign - with custom type", () => {
       message: `BugType TYPO is not accepted from CP1.`,
     });
   });
+  it("Should answer 200 if a user sends custom bug-type disabled but exist as custom type", async () => {
+    const response = await request(app)
+      .post("/users/me/campaigns/1/bugs")
+      .set("authorization", "Bearer tester")
+      .send({
+        ...bug,
+        type: "OTHER",
+      });
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty("type", "OTHER");
+  });
 });
-
 describe("Route POST a bug to a specific campaign - with custom severities", () => {
   useBasicData();
   beforeEach(async () => {
@@ -642,7 +680,6 @@ describe("Route POST a bug to a specific campaign - with custom severities", () 
     });
   });
 });
-
 describe("Route POST a bug to a specific campaign - with custom replicability", () => {
   useBasicData();
   beforeEach(async () => {
@@ -767,7 +804,6 @@ describe("Route POST a bug to a specific campaign - with user has not devices", 
     expect(response.status).toBe(403);
   });
 });
-
 describe("Route POST a bug to a specific campaign - with invalid additional fields", () => {
   useBasicData();
   beforeEach(async () => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3219,16 +3219,7 @@ export interface operations {
             severity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
             /** @enum {string} */
             replicability: "ONCE" | "SOMETIMES" | "ALWAYS";
-            /** @enum {string} */
-            type:
-              | "CRASH"
-              | "GRAPHIC"
-              | "MALFUNCTION"
-              | "OTHER"
-              | "PERFORMANCE"
-              | "SECURITY"
-              | "TYPO"
-              | "USABILITY";
+            type: string;
             notes: string;
             usecase: string;
             device: components["schemas"]["UserDevice"];
@@ -3254,16 +3245,7 @@ export interface operations {
           severity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
           /** @enum {string} */
           replicability: "ONCE" | "SOMETIMES" | "ALWAYS";
-          /** @enum {string} */
-          type:
-            | "CRASH"
-            | "GRAPHIC"
-            | "MALFUNCTION"
-            | "OTHER"
-            | "PERFORMANCE"
-            | "SECURITY"
-            | "TYPO"
-            | "USABILITY";
+          type: string;
           notes: string;
           lastSeen: string;
           usecase: number;


### PR DESCRIPTION
# ✨ Update Campaign Class and API Bug Type Management

## 📝 Description
This pull request introduces changes to the `Campaign` class, modifies the design and schema of certain APIs, and adds comprehensive test coverage for the new behavior.

### Changes Introduced:

#### 1. Modifications to the `Campaign` Class:
- Updated the `getAvailableTypesItems()` method:
  - **New Behavior**: If no custom types are defined, only `enabled` types are returned.
  - **With Custom Types**: When custom types are present, the method returns the selected custom types, even if they are `enabled = 0`.
- Removed the `isValidBugType()` method.

#### 2. API Design and Schema Changes:
- In `POST /users/me/campaigns/{campaignId}/bugs`:
  - Removed the enum for `bug type` from both the request body and the response body.
  - Enum values removed:
    - `CRASH`
    - `GRAPHIC`
    - `MALFUNCTION`
    - `OTHER`
    - `PERFORMANCE`
    - `SECURITY`
    - `TYPO`
    - `USABILITY`

#### 3. Additional Test Cases:
- **GET /users/me/campaigns/{campaignId}/**:
  - Should return selected bug types even if types are disabled (when there are custom bug type).
  - Should return non-standard (enabled and disabled) custom bug types as valid.

- **POST /users/me/campaigns/{campaignId}/bugs/**:
  - Should return `200` if an existing (and enabled) bug type is sent to `wp_appq_evd_bug_type`.
  - Should return `200` if a non-standard (and enabled) bug type is sent to `wp_appq_evd_bug_type`.
  - Should return `200` if a user sends a custom bug type that is disabled but exists as a custom type.
  - Should return an error if send an existent (disabled) bug TYPE on wp_appq_evd_bug_type (case default bugtypes)
  - Should return an error if a user sends a bug-type not included as custom (case custom/addictional bugtypes)

## 🚀 Features
- **Updated Method**:
  - `Campaign.getAvailableTypesItems()` with enhanced behavior for custom and enabled types.
- **API Enhancements**:
  - Simplified `POST /users/me/campaigns/{campaignId}/bugs` schema by removing the `bug type` enum.

## 🛠️ How to Test
1. **GET /users/me/campaigns/{campaignId}/**:
   - Verify that selected bug types are returned even if types are disabled and selected as custom type.
   - Validate that non-standard custom bug types (enabled and disabled) are considered valid (manually insert requested).

2. **POST /users/me/campaigns/{campaignId}/bugs/**:
   - Send an existing, enabled bug type and expect a `200` response.
   - Send a non-standard, enabled bug type and expect a `200` response.
   - Send a disabled custom bug type (if it exists as a custom type) and expect a `200` response.