### PR TITLE
UN-769 - 🚀 Add skipPagesAndTasks Option to /dossiers Route & New Test ✅

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -9454,6 +9454,55 @@ paths:
                           type: integer
                         campaign:
                           type: integer
+                - type: object
+                  properties:
+                    skipPagesAndTasks:
+                      type: integer
+                      minimum: 0
+                      maximum: 1
+                      default: 0
+            examples:
+              Example 1:
+                value:
+                  project: 0
+                  testType: 0
+                  title:
+                    customer: string
+                    tester: string
+                  startDate: '2019-08-24T14:15:22Z'
+                  endDate: '2019-08-24T14:15:22Z'
+                  closeDate: '2019-08-24T14:15:22Z'
+                  deviceList:
+                    - 0
+                  csm: 0
+                  roles:
+                    - role: 0
+                      user: 0
+                  description: string
+                  productLink: string
+                  goal: string
+                  outOfScope: string
+                  deviceRequirements: string
+                  target:
+                    notes: string
+                    size: 0
+                    cap: 0
+                  countries:
+                    - st
+                  languages:
+                    - string
+                  browsers:
+                    - 0
+                  productType: 0
+                  notes: string
+                  duplicate:
+                    fields: 0
+                    useCases: 0
+                    mailMerges: 0
+                    pages: 0
+                    testers: 0
+                    campaign: 0
+                  skipPagesAndTasks: 0
   '/dossiers/{campaign}':
     parameters:
       - name: campaign

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -137,11 +137,15 @@ export default class RouteItem extends UserRoute<{
   }
 
   protected async prepare(): Promise<void> {
+    const { skipPagesAndTasks } = this.getBody();
+
     try {
       const campaignId = await this.createCampaign();
       await this.linkRolesToCampaign(campaignId);
 
-      await this.generateLinkedData(campaignId);
+      if (!skipPagesAndTasks) {
+        await this.generateLinkedData(campaignId);
+      }
 
       const webhook = new WebhookTrigger({
         type: "campaign_created",
@@ -370,7 +374,6 @@ export default class RouteItem extends UserRoute<{
 
   private async generateLinkedData(campaignId: number) {
     const apiTrigger = new WordpressJsonApiTrigger(campaignId);
-
     await apiTrigger.generateTasks();
 
     if (this.duplicate.fieldsFrom) await this.duplicateFields(campaignId);

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -9,7 +9,7 @@ import crypto from "crypto";
 import { serialize } from "php-serialize";
 import { unserialize } from "php-unserialize";
 
-export default class RouteItem extends UserRoute<{
+export default class PostDossiers extends UserRoute<{
   response: StoplightOperations["post-dossiers"]["responses"]["201"]["content"]["application/json"];
   body: StoplightOperations["post-dossiers"]["requestBody"]["content"]["application/json"];
 }> {

--- a/src/routes/dossiers/_post/triggerWp.spec.ts
+++ b/src/routes/dossiers/_post/triggerWp.spec.ts
@@ -79,6 +79,17 @@ describe("Route POST /dossiers - duplication", () => {
     ).toHaveBeenCalledTimes(1);
   });
 
+  it("Should not call WordpressJsonApiTrigger if send skiPagesAndTasks = 1", async () => {
+    const response = await request(app)
+      .post("/dossiers")
+      .send({ ...baseRequest, skipPagesAndTasks: 1 })
+      .set("Authorization", "Bearer admin");
+
+    expect(response.status).toBe(201);
+
+    expect(WordpressJsonApiTrigger).toHaveBeenCalledTimes(0);
+  });
+
   it("Should post to wordpress if pages is not duplicated", async () => {
     const response = await request(app)
       .post("/dossiers")

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -4118,6 +4118,8 @@ export interface operations {
             testers?: number;
             campaign?: number;
           };
+        } & {
+          skipPagesAndTasks?: number;
         };
       };
     };


### PR DESCRIPTION
# ✨ Changes Introduced:

## The POST /dossiers route now accepts a new optional request body parameter:
skipPagesAndTasks: 0 | 1 (default: 0)

## If skipPagesAndTasks: 1 is provided, the route skips calling generateLinkedData():
```typescript
if (!skipPagesAndTasks) {
    await this.generateLinkedData(campaignId);
}
```

----------

- 🧪 Added test case:
- ✅ "Should not call WordpressJsonApiTrigger if skipPagesAndTasks = 1"

---------

📌 Why these changes?
This improvement allows more flexibility when creating dossiers, avoiding unnecessary data generation when not needed. 🚀