### PR TITLE
Enhance GET /campaigns with quotation data

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@appquality/tryber-database": "^0.42.2",
+    "@appquality/tryber-database": "^0.42.22",
     "@appquality/wp-auth": "^1.0.7",
     "@googlemaps/google-maps-services-js": "^3.3.7",
     "@sendgrid/mail": "^7.6.0",

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -761,7 +761,64 @@ paths:
                                 required:
                                   - role
                                   - user
+                            quote:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+                                price:
+                                  type: string
+                                status:
+                                  type: string
+                              required:
+                                - id
+                                - price
+                                - status
                   - $ref: '#/components/schemas/PaginationData'
+              examples:
+                Example 1:
+                  value:
+                    items:
+                      - id: 0
+                        name: string
+                        customerTitle: string
+                        startDate: string
+                        endDate: string
+                        status: running
+                        visibility: admin
+                        resultType: bug
+                        csm:
+                          id: 0
+                          name: string
+                          surname: string
+                        customer:
+                          id: 0
+                          name: string
+                        type:
+                          name: string
+                          area: quality
+                        project:
+                          id: 0
+                          name: string
+                        phase:
+                          id: 0
+                          name: string
+                        roles:
+                          - role:
+                              id: 0
+                              name: string
+                            user:
+                              id: 0
+                              name: string
+                              surname: string
+                        quote:
+                          id: 0
+                          price: string
+                          status: string
+                    start: 0
+                    limit: 0
+                    size: 0
+                    total: 0
         '403':
           $ref: '#/components/responses/NotAuthorized'
         '404':

--- a/src/routes/campaigns/_get/fields.spec.ts
+++ b/src/routes/campaigns/_get/fields.spec.ts
@@ -155,7 +155,7 @@ describe("GET /campaigns", () => {
         status_id: 1,
         campaign_type_id: 1,
         plan_id: 15, // plan from quoted template
-        quote_id: 50, // TODO
+        quote_id: 50,
       },
       {
         ...campaign,
@@ -177,7 +177,7 @@ describe("GET /campaigns", () => {
         status_id: 2,
         campaign_type_id: 2,
         plan_id: 16, // plan from unquoted template
-        quote_id: 55, // TODO
+        quote_id: 55,
       },
     ]);
   });

--- a/src/routes/campaigns/_get/filterBy.spec.ts
+++ b/src/routes/campaigns/_get/filterBy.spec.ts
@@ -311,4 +311,16 @@ describe("GET /campaigns", () => {
     expect(response.body.items).toHaveLength(2);
     expect(response.body.total).toBe(2);
   });
+  describe("Filter campaigns for quotation-table on dossier", () => {
+    it("Should return only campaigns having a quotation of a specific customer", async () => {
+      const response = await request(app)
+        .get(
+          "/campaigns?fields=id,title,startDate,phase,quote&filterBy[customer]=1&filterBy[hasQuote]"
+        )
+        .set("Authorization", 'Bearer tester olp {"appq_campaign":true}');
+      console.log(response.body);
+      expect(response.status).toBe(200);
+      expect(response.body.items).toHaveLength(1);
+    });
+  });
 });

--- a/src/routes/campaigns/_get/filterBy.spec.ts
+++ b/src/routes/campaigns/_get/filterBy.spec.ts
@@ -19,6 +19,32 @@ const campaign = {
   customer_title: "",
   campaign_pts: 200,
 };
+const requiredModules = [
+  {
+    type: "title" as const,
+    variant: "primary",
+    output: "Project Kickoff",
+  },
+  {
+    type: "dates" as const,
+    variant: "default",
+    output: {
+      start: "2025-01-01",
+    },
+  },
+  {
+    type: "tasks" as const,
+    variant: "default",
+    output: [
+      {
+        kind: "bug" as const,
+        title: "Task bug",
+      },
+    ],
+  },
+];
+const quotedTemplateId = 90;
+const unquotedTemplateId = 91;
 describe("GET /campaigns", () => {
   beforeAll(async () => {
     await tryber.tables.CampaignPhase.do().insert([
@@ -41,6 +67,83 @@ describe("GET /campaigns", () => {
         category_id: 1,
       },
     ]);
+    await tryber.tables.WpAppqProject.do().insert([
+      {
+        id: 1,
+        display_name: "Project 1",
+        customer_id: 1,
+        edited_by: 1,
+      },
+      {
+        id: 2,
+        display_name: "Project 2",
+        customer_id: 2,
+        edited_by: 1,
+      },
+      {
+        id: 3,
+        display_name: "Project 3",
+        customer_id: 3,
+        edited_by: 1,
+      },
+    ]);
+    await tryber.tables.CpReqTemplates.do().insert([
+      {
+        id: quotedTemplateId,
+        name: "Template Name",
+        config: JSON.stringify({
+          modules: requiredModules,
+        }),
+        price: "1000",
+      },
+      {
+        id: unquotedTemplateId,
+        name: "Template Name",
+        config: JSON.stringify({
+          modules: requiredModules,
+        }),
+      },
+    ]);
+    await tryber.tables.CpReqPlans.do().insert([
+      {
+        id: 15,
+        name: "Plan Name",
+        config: JSON.stringify({
+          modules: requiredModules,
+        }),
+        project_id: campaign.project_id,
+        template_id: quotedTemplateId,
+      },
+      {
+        id: 16,
+        name: "Plan Name",
+        config: JSON.stringify({
+          modules: requiredModules,
+        }),
+        project_id: 2,
+        template_id: unquotedTemplateId,
+      },
+    ]);
+    await tryber.tables.CpReqQuotations.do().insert([
+      {
+        id: 50,
+        plan_id: 15,
+        estimated_cost: "2 kilotons",
+        status: "confirmed",
+        config: JSON.stringify({
+          modules: requiredModules,
+        }),
+      },
+      {
+        id: 55,
+        plan_id: 16,
+        estimated_cost: "3000 electronvolts",
+        status: "proposed",
+        config: JSON.stringify({
+          modules: requiredModules,
+        }),
+      },
+    ]);
     await tryber.tables.WpAppqEvdProfile.do().insert([
       {
         id: 1,
@@ -52,38 +155,17 @@ describe("GET /campaigns", () => {
         employment_id: 1,
       },
     ]);
-    await tryber.tables.WpAppqProject.do().insert([
-      {
-        id: 1,
-        display_name: "Project 1",
-        customer_id: 1,
-        edited_by: 1,
-      },
-    ]);
-    await tryber.tables.WpAppqProject.do().insert([
-      {
-        id: 2,
-        display_name: "Project 2",
-        customer_id: 2,
-        edited_by: 1,
-      },
-    ]);
-    await tryber.tables.WpAppqProject.do().insert([
-      {
-        id: 3,
-        display_name: "Project 3",
-        customer_id: 3,
-        edited_by: 1,
-      },
-    ]);
+
     await tryber.tables.WpAppqEvdCampaign.do().insert([
       {
         ...campaign,
         id: 1,
         title: "First campaign",
-        project_id: 1,
         status_id: 1,
         campaign_type_id: 1,
+        project_id: 1,
+        plan_id: 15,
+        quote_id: 50,
       },
       {
         ...campaign,
@@ -103,6 +185,8 @@ describe("GET /campaigns", () => {
         project_id: 2,
         status_id: 2,
         campaign_type_id: 3,
+        plan_id: 16,
+        quote_id: 55,
       },
     ]);
   });
@@ -209,6 +293,14 @@ describe("GET /campaigns", () => {
         expect.objectContaining({ id: 3, name: "Third campaign" }),
       ])
     );
+  });
+
+  it("Should return only campaigns having a quotation if filterBy is set", async () => {
+    const response = await request(app)
+      .get("/campaigns?filterBy[hasQuote]")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":true}');
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
   });
 
   it("Should return total based on filter", async () => {

--- a/src/routes/campaigns/_get/index.ts
+++ b/src/routes/campaigns/_get/index.ts
@@ -56,6 +56,7 @@ class RouteItem extends UserRoute<{
       value: number[] | "empty";
     }[];
     phase?: number[];
+    hasQuote?: boolean;
   } = {};
 
   constructor(configuration: RouteClassConfiguration) {
@@ -132,6 +133,9 @@ class RouteItem extends UserRoute<{
         const phaseIds = (query.filterBy as any).phase.split(",").map(Number);
         this.filterBy.phase = phaseIds;
       }
+      if (Object.keys(query.filterBy as any).includes("hasQuote")) {
+        this.filterBy.hasQuote = true;
+      }
     }
   }
 
@@ -194,7 +198,6 @@ class RouteItem extends UserRoute<{
     }
 
     query.orderBy(this.orderBy, this.order);
-
     const results: {
       id?: number;
       name?: string;
@@ -504,6 +507,9 @@ class RouteItem extends UserRoute<{
           this.filterBy.phase
         );
       }
+      if (this.filterBy.hasQuote) {
+        query = query.whereNotNull("wp_appq_evd_campaign.quote_id");
+      }
     });
   }
 
@@ -608,6 +614,7 @@ class RouteItem extends UserRoute<{
       }
     });
   }
+
   private addStatusTo(query: CampaignSelect) {
     query.modify((query) => {
       if (this.fields.includes("status")) {
@@ -615,6 +622,7 @@ class RouteItem extends UserRoute<{
       }
     });
   }
+
   private addTypeTo(query: CampaignSelect) {
     query.modify((query) => {
       if (this.fields.includes("type")) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1289,6 +1289,11 @@ export interface operations {
                   surname: string;
                 };
               }[];
+              quote?: {
+                id: number;
+                price: string;
+                status: string;
+              };
             }[];
           } & components["schemas"]["PaginationData"];
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
     "@babel/parser" "^7.22.5"
     "@babel/traverse" "^7.22.5"
 
-"@appquality/tryber-database@^0.42.2":
-  version "0.42.2"
-  resolved "https://registry.npmjs.org/@appquality/tryber-database/-/tryber-database-0.42.2.tgz#2b541c89657a64c223ca354578e388670f21b59a"
-  integrity sha512-zYQb6Pjpm7+TDxndiXReeQV0ROZqSLDvEc1YRz4AQZUuYGR2o+x8QBNhKfx4ixn0H2o+XbaGl8jB0U1oEkXftQ==
+"@appquality/tryber-database@^0.42.22":
+  version "0.42.22"
+  resolved "https://registry.yarnpkg.com/@appquality/tryber-database/-/tryber-database-0.42.22.tgz#40ceeb399d3358bece04f18a0949034bfdbb3416"
+  integrity sha512-DEWnhsyBijrhjT5seQANLiNM+nL5MaXHOqmCU/ChhIZQBPZvv9J7qnGfEdn0jWk41aFPOofXm3mYwY2A8b8Tnw==
   dependencies:
     better-sqlite3 "^8.1.0"
     knex "^2.5.1"


### PR DESCRIPTION
- Should retrun campaigns id,quote if fields is set with id,quote
  - .get("/campaigns?fields=quote,id")
- Should return only campaigns having a quotation if filterBy is set
  - .get("/campaigns?filterBy[hasQuote]")
-  Filter campaigns for quotation-table on dossier - Should return only campaigns having a quotation of a specific customer
   - .get("campaigns?fields=id,title,startDate,phase,quote&filterBy[customer]=1&filterBy[hasQuote]")