### PR TITLE
Refactor forms route to use tryber

### DIFF
--- a/.project-management/current-prd/tasks-prd-db-class-migration.md
+++ b/.project-management/current-prd/tasks-prd-db-class-migration.md
@@ -48,6 +48,7 @@ features/wp
 
 ### Existing Files Modified
 
+- `src/routes/campaigns/forms/_get/index.ts` - migrated to use `tryber` instead of db class
 - Modules in `src/features` and `src/routes` that rely on deprecated classes
 - Test files associated with the above modules
 
@@ -60,6 +61,7 @@ features/wp
 
 - [x] 1.0 Inventory current usage of classes from `src/features/db/class`
 - [ ] 2.0 Refactor identified modules to use `tryber` queries via `src/features/database.ts`
+- [x] 2.1 Refactor `src/routes/campaigns/forms/_get/index.ts` to use `tryber`
 - [ ] 3.0 Update or create tests to cover the refactored code
 - [ ] 4.0 Remove deprecated classes once all references are migrated
 - [ ] 5.0 Run full test suite and verify no regressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 2025-06-05 - add PRD for database class migration
 2025-06-05 - add high-level tasks for db class migration PRD
+2025-06-05 - refactor campaigns forms route to use tryber

--- a/src/routes/campaigns/forms/_get/index.ts
+++ b/src/routes/campaigns/forms/_get/index.ts
@@ -1,13 +1,13 @@
 /** OPENAPI-CLASS: get-campaigns-forms */
 
 import UserRoute from "@src/features/routes/UserRoute";
-import PreselectionForms from "@src/features/db/class/PreselectionForms";
+import { tryber } from "@src/features/database";
+import { Knex } from "knex";
 
 export default class RouteItem extends UserRoute<{
   response: StoplightOperations["get-campaigns-forms"]["responses"][200]["content"]["application/json"];
   query: StoplightOperations["get-campaigns-forms"]["parameters"]["query"];
 }> {
-  private db: { forms: PreselectionForms };
   private limit: number | undefined;
   private start: number;
   private searchBy: ("name" | "campaign_id")[] | undefined;
@@ -15,7 +15,6 @@ export default class RouteItem extends UserRoute<{
 
   constructor(config: RouteClassConfiguration) {
     super(config);
-    this.db = { forms: new PreselectionForms(["id", "name", "campaign_id"]) };
     const query = this.getQuery();
     this.limit = parseInt(query.limit as unknown as string) || undefined;
     this.start = parseInt((query.start as unknown as string) || "0");
@@ -51,37 +50,42 @@ export default class RouteItem extends UserRoute<{
   }
 
   private async getForms() {
-    const results = await this.db.forms.query({
-      limit: this.limit,
-      where: this.getWhere(),
-      orderBy: [{ field: "id", order: "DESC" }],
-      offset: this.start,
-    });
-    return results.map((form) => {
-      return {
-        id: form.id,
-        name: form.name,
-        campaign: form.campaign_id !== null ? form.campaign_id : undefined,
-      };
-    });
+    const query = tryber.tables.WpAppqCampaignPreselectionForm.do()
+      .select("id", "name", "campaign_id")
+      .orderBy("id", "DESC")
+      .offset(this.start);
+
+    if (this.limit) query.limit(this.limit);
+    this.applySearch(query);
+
+    const results = await query;
+    return results.map((form) => ({
+      id: form.id,
+      name: form.name,
+      campaign: form.campaign_id !== null ? form.campaign_id : undefined,
+    }));
   }
 
   private async getTotal() {
-    const results = await this.db.forms.query({ where: this.getWhere() });
-    return this.limit ? results.length : undefined;
+    if (this.limit === undefined) return undefined;
+    const query = tryber.tables.WpAppqCampaignPreselectionForm.do().count({
+      count: "id",
+    });
+    this.applySearch(query);
+    const result = await query;
+    const total = result[0].count as number | string;
+    return typeof total === "number" ? total : parseInt(total);
   }
 
-  private getWhere() {
-    if (!this.searchBy || !this.search) return undefined;
-    const searchFields = this.searchBy;
+  private applySearch(query: Knex.QueryBuilder) {
+    if (!this.searchBy || !this.search) return;
     const search = this.search;
-    const orQuery: PreselectionForms["where"][number] = searchFields.map(
-      (searchField) => {
-        return { [searchField]: "%" + search + "%", isLike: true };
-      }
-    );
-
-    return [orQuery];
+    query.where((builder) => {
+      this.searchBy!.forEach((field, index) => {
+        const method = index === 0 ? "where" : "orWhere";
+        (builder as any)[method](field, "like", `%${search}%`);
+      });
+    });
   }
   private isSearchByAcceptable(searchField: string) {
     return ["name", "campaign_id"].includes(searchField);


### PR DESCRIPTION
## Summary
- migrate campaigns forms listing to knex via `tryber`
- record work in PRD tasks
- note change in changelog

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6841ae8f0f88832bb0936cd76421755c