### PR TITLE
Fix unguess post watcher body

### DIFF
--- a/src/features/class/Unguess.ts
+++ b/src/features/class/Unguess.ts
@@ -95,7 +95,7 @@ class Unguess {
     campaignId: number;
   }): Promise<{ result: any }> {
     const body = {
-      ...profileIds,
+      users: profileIds.users,
     };
     const result = await this.authPost(
       `/campaigns/${campaignId}/watchers`,

--- a/src/features/class/Unguess.ts
+++ b/src/features/class/Unguess.ts
@@ -28,7 +28,29 @@ class Unguess {
     });
 
     if (!response.ok) {
-      throw new Error("Failed to authenticate: " + response.statusText);
+      let errorBody: unknown = undefined;
+      try {
+        const text = await response.text();
+        try {
+          errorBody = text ? JSON.parse(text) : text;
+        } catch {
+          errorBody = text;
+        }
+      } catch {
+        // ignore
+      }
+
+      const error: any = new Error(
+        `Failed to authenticate: ${response.status} ${response.statusText}`
+      );
+      error.status = response.status;
+      error.statusText = response.statusText;
+      error.response = {
+        status: response.status,
+        statusText: response.statusText,
+        data: errorBody,
+      };
+      throw error;
     }
 
     const data = await response.json();
@@ -57,9 +79,32 @@ class Unguess {
     });
 
     if (!response.ok) {
-      throw new Error(`Failed to post to ${path}: ${response.statusText}`);
+      let errorBody: unknown = undefined;
+
+      try {
+        const text = await response.text();
+        try {
+          errorBody = text ? JSON.parse(text) : text;
+        } catch {
+          errorBody = text;
+        }
+      } catch {}
+
+      const error: any = new Error(
+        `Failed to post to ${path}: ${response.status} ${response.statusText}`
+      );
+      error.status = response.status;
+      error.statusText = response.statusText;
+      error.response = {
+        status: response.status,
+        statusText: response.statusText,
+        data: errorBody,
+      };
+
+      throw error;
     }
 
+    // Se ok, ritorniamo il JSON come prima
     return response.json();
   }
 
@@ -103,7 +148,7 @@ class Unguess {
     );
     console.warn("postCampaignWatchers result:", result);
     return {
-      result: result,
+      result,
     };
   }
 }

--- a/src/features/class/Unguess.ts
+++ b/src/features/class/Unguess.ts
@@ -95,7 +95,7 @@ class Unguess {
     campaignId: number;
   }): Promise<{ result: any }> {
     const body = {
-      users: profileIds.users,
+      users: profileIds.users.map(({ id }) => ({ id })),
     };
     const result = await this.authPost(
       `/campaigns/${campaignId}/watchers`,

--- a/src/features/class/Unguess.ts
+++ b/src/features/class/Unguess.ts
@@ -101,6 +101,7 @@ class Unguess {
       `/campaigns/${campaignId}/watchers`,
       body
     );
+    console.debug("postCampaignWatchers result:", result);
     return {
       result: result,
     };

--- a/src/features/class/Unguess.ts
+++ b/src/features/class/Unguess.ts
@@ -146,7 +146,6 @@ class Unguess {
       `/campaigns/${campaignId.toString()}/watchers`,
       body
     );
-    console.warn("postCampaignWatchers result:", result);
     return {
       result,
     };

--- a/src/features/class/Unguess.ts
+++ b/src/features/class/Unguess.ts
@@ -95,13 +95,13 @@ class Unguess {
     campaignId: number;
   }): Promise<{ result: any }> {
     const body = {
-      users: profileIds.users.map(({ id }) => ({ id })),
+      ...profileIds,
     };
     const result = await this.authPost(
-      `/campaigns/${campaignId}/watchers`,
+      `/campaigns/${campaignId.toString()}/watchers`,
       body
     );
-    console.debug("postCampaignWatchers result:", result);
+    console.warn("postCampaignWatchers result:", result);
     return {
       result: result,
     };

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -885,9 +885,8 @@ export default class PostDossiers extends UserRoute<{
         "Error setting up notifications calling unguess api:",
         error
       );
-
       // @ts-ignore
-      console.error("error details: ", error?.response?.data);
+      console.error("Error details: ", error?.response?.data);
       return;
     }
   }

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -884,6 +884,8 @@ export default class PostDossiers extends UserRoute<{
         "Error setting up notifications calling unguess api:",
         error
       );
+      // @ts-ignore
+      console.error(error.response.data);
       return;
     }
   }

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -8,6 +8,7 @@ import { WebhookTrigger } from "@src/features/webhookTrigger";
 import { importPages } from "@src/features/wp/Pages/importPages";
 import WordpressJsonApiTrigger from "@src/features/wp/WordpressJsonApiTrigger";
 import { components } from "@src/schema";
+import { AxiosError } from "axios";
 import Province from "comuni-province-regioni/lib/province";
 
 const MIN_TESTER_AGE = 14;
@@ -879,13 +880,14 @@ export default class PostDossiers extends UserRoute<{
         campaignId: campaignId,
       });
       return result;
-    } catch (error) {
+    } catch (error: any) {
       console.error(
         "Error setting up notifications calling unguess api:",
         error
       );
+
       // @ts-ignore
-      console.error(error.response.data);
+      console.error("error details: ", error?.response?.data);
       return;
     }
   }


### PR DESCRIPTION
This pull request primarily improves error handling and data validation in the `Unguess` class and the `PostDossiers` route. The main changes include providing more detailed error information for failed API calls, ensuring robust parsing of error responses, and validating user IDs before returning them. These updates help with debugging and prevent invalid data from propagating through the system.

### Improved error handling in API requests

* Enhanced error handling in `Unguess.ts` for authentication and POST requests: now, when a request fails, the thrown error includes the HTTP status, status text, and a parsed error body (if available), making debugging easier. [[1]](diffhunk://#diff-079bdede1884ecef0a50da7c562be6d3ba2f9a4d0348b9130588ccde411cda6dL31-R53) [[2]](diffhunk://#diff-079bdede1884ecef0a50da7c562be6d3ba2f9a4d0348b9130588ccde411cda6dL60-R107)

### Data validation and robustness

* In the `PostDossiers` route, user IDs returned from `retrieveProjectAndWorkspaceUsers` are now filtered to ensure they are positive integers, preventing invalid IDs from being included. If no valid IDs are found, the function returns `undefined`.
* The join and selection logic in `retrieveProjectAndWorkspaceUsers` was updated to use a direct string reference for `customer_id`, improving query clarity and correctness.

### Minor improvements

* The campaign ID in the watcher API call is now explicitly converted to a string to avoid potential type issues.
* Added `AxiosError` import in `index.ts` for potential future error handling enhancements.