### PR TITLE
UN-2153 has plan dossier

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^3.14.1",
     "tscpaths": "^0.0.9",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.3",
+    "yaml-sort": "2"
   }
 }

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -804,6 +804,9 @@ components:
           type: string
         goal:
           type: string
+        hasPlan:
+          default: false
+          type: boolean
         languages:
           items:
             type: string
@@ -13132,4 +13135,3 @@ tags:
   - name: Projects
   - name: Task
   - name: User
-  - name: Admin

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -804,9 +804,6 @@ components:
           type: string
         goal:
           type: string
-        hasPlan:
-          default: false
-          type: boolean
         languages:
           items:
             type: string
@@ -6335,6 +6332,10 @@ paths:
                     type: array
                   deviceRequirements:
                     type: string
+
+                  hasPlan:
+                    default: false
+                    type: boolean
                   endDate:
                     format: date-time
                     type: string

--- a/src/routes/dossiers/campaignId/_get/index.spec.ts
+++ b/src/routes/dossiers/campaignId/_get/index.spec.ts
@@ -284,6 +284,52 @@ describe("Route GET /dossiers/:id", () => {
     expect(response.body.phase).toHaveProperty("name", "Active");
   });
 
+  describe("Campaign Plan", () => {
+    beforeEach(async () => {
+      await tryber.tables.CpReqPlans.do().insert({
+        id: 1,
+        name: "Standard Plan",
+        config: "config",
+      });
+      await tryber.tables.WpAppqEvdCampaign.do().insert({
+        id: 2,
+        project_id: 1,
+        campaign_type_id: 1,
+        title: "Test Campaign",
+        customer_title: "Test Customer Campaign",
+        start_date: "2019-08-24T14:15:22Z",
+        end_date: "2019-08-24T14:15:22Z",
+        close_date: "2019-08-27T14:15:22Z",
+        platform_id: 0,
+        os: "1",
+        page_manual_id: 0,
+        page_preview_id: 0,
+        pm_id: 1,
+        customer_id: 0,
+        desired_number_of_testers: 100,
+        auto_apply: 1,
+        plan_id: 1,
+      });
+    });
+    afterEach(async () => {
+      await tryber.tables.WpAppqEvdCampaign.do().delete().where("id", 2);
+      await tryber.tables.CpReqPlans.do().delete();
+    });
+    it("Should return whether the campaign has a plan or not", async () => {
+      const response = await request(app)
+        .get("/dossiers/1")
+        .set("authorization", "Bearer admin");
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("hasPlan", false);
+
+      const responseWithPlan = await request(app)
+        .get("/dossiers/2")
+        .set("authorization", "Bearer admin");
+      expect(responseWithPlan.status).toBe(200);
+      expect(responseWithPlan.body).toHaveProperty("hasPlan", true);
+    });
+  });
+
   describe("With dossier data", () => {
     beforeAll(async () => {
       await tryber.tables.CampaignDossierData.do().insert({

--- a/src/routes/dossiers/campaignId/_get/index.ts
+++ b/src/routes/dossiers/campaignId/_get/index.ts
@@ -71,7 +71,8 @@ export default class RouteItem extends UserRoute<{
           .as("phase_id"),
         tryber.ref("name").withSchema("campaign_phase").as("phase_name"),
         tryber.ref("auto_apply").withSchema("wp_appq_evd_campaign"),
-        tryber.ref("auto_approve").withSchema("wp_appq_evd_campaign")
+        tryber.ref("auto_approve").withSchema("wp_appq_evd_campaign"),
+        tryber.ref("plan_id").withSchema("wp_appq_evd_campaign")
       )
       .join(
         "wp_appq_project",
@@ -226,6 +227,7 @@ export default class RouteItem extends UserRoute<{
     try {
       this.setSuccess(200, {
         id: this.campaign.id,
+        hasPlan: this.campaign.plan_id != null,
         title: {
           customer: this.campaign.customer_title,
           tester: this.campaign.title,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -967,6 +967,7 @@ export interface components {
       /** Format: date-time */
       endDate?: string;
       goal?: string;
+      hasPlan?: boolean;
       languages?: string[];
       notes?: string;
       outOfScope?: string;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -967,7 +967,6 @@ export interface components {
       /** Format: date-time */
       endDate?: string;
       goal?: string;
-      hasPlan?: boolean;
       languages?: string[];
       notes?: string;
       outOfScope?: string;
@@ -3021,6 +3020,7 @@ export interface operations {
               name: string;
             }[];
             deviceRequirements?: string;
+            hasPlan?: boolean;
             /** Format: date-time */
             endDate: string;
             goal?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2711,6 +2711,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -4606,6 +4615,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
 
 js-yaml@^4.1.0:
   version "4.1.0"
@@ -6970,6 +6986,14 @@ yallist@^5.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
+yaml-sort@2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/yaml-sort/-/yaml-sort-2.1.0.tgz#ee27132a446d359c26e4e67a02bd16d1d230e279"
+  integrity sha512-iiGmT3MvzfHYY7hepMdx1a2tCG6ltHRF8fSGGE4zwxPLNo2tD0KHjwLRtWThBYT71F5qTWObo6pKdZ9UYHHD5A==
+  dependencies:
+    js-yaml "^4.0.0"
+    yargs "^17.0.0"
+
 yargs-parser@^20.2.2, yargs-parser@^20.x:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
@@ -6979,6 +7003,11 @@ yargs-parser@^21.0.0:
   version "21.0.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^16.1.0:
   version "16.2.0"
@@ -6992,6 +7021,19 @@ yargs@^16.1.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.0.0:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^17.3.1:
   version "17.5.1"


### PR DESCRIPTION
This pull request introduces support for a new `hasPlan` property in the campaign dossier API response, indicating whether a campaign is associated with a plan. It also refactors the OpenAPI schema to improve the definition of required properties for various objects, ensuring better type safety and documentation accuracy.

#### API Feature Addition

* Added a `hasPlan` boolean property to the dossier API response, reflecting if the campaign has an associated plan (`plan_id` is not null). This is now included in both the implementation (`RouteItem` in `index.ts`) and the OpenAPI schema (`src/schema.ts`, `src/reference/openapi.yml`). [[1]](diffhunk://#diff-9c08d8b51f2b54bd073509775a8f89e1cb9bcb84ba22c86da878723b222b5db2R230) [[2]](diffhunk://#diff-1b1f8e32f0a3581b6418901d5ef0e1de13b840515925f11e9ada1a2b4693149bR3021) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dL5031-R5049)

#### Schema Improvements

* Updated the OpenAPI schema to explicitly declare required fields for campaign objects and nested arrays, improving validation and documentation. This includes moving `required` declarations for properties like `autoApply`, `autoApprove`, `closeDate`, etc., to the correct location and ensuring array items have their required fields defined. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR4811-R4824) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR4841-L4834) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR4884-L4877) [[4]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR4905-L4895) [[5]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR4928-L4921) [[6]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR4953-L4959) [[7]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR5015-L5022)

#### Testing Enhancements

* Added new tests in `index.spec.ts` to verify that the dossier API correctly returns the `hasPlan` property for campaigns with and without an associated plan.

#### Implementation Changes

* Modified the database query to select the `plan_id` field, enabling the backend logic to determine the value of `hasPlan` for each campaign.