### PR TITLE
release-20251212

### DIFF
--- a/src/routes/dossiers/campaignId/agreements/_put/index.spec.ts
+++ b/src/routes/dossiers/campaignId/agreements/_put/index.spec.ts
@@ -210,6 +210,22 @@ describe("Route PUT /dossiers/:id/agreements", () => {
         expect(campaign?.tokens_usage).toBe(7.5);
       });
 
+      it("Should update the tokens usage and return 200 also with tokens=0", async () => {
+        const response = await request(app)
+          .put("/dossiers/1/agreements")
+          .send({ agreementId: 1, tokens: 0 })
+          .set("Authorization", "Bearer admin");
+
+        expect(response.status).toBe(200);
+
+        const campaign = await tryber.tables.WpAppqEvdCampaign.do()
+          .select("tokens_usage")
+          .where("id", 1)
+          .first();
+
+        expect(campaign?.tokens_usage).toBe(0);
+      });
+
       describe("Link between campaign and agreement does not exists", () => {
         it("Should create the link between campaign and agreement", async () => {
           const response = await request(app)

--- a/src/routes/dossiers/campaignId/agreements/_put/index.ts
+++ b/src/routes/dossiers/campaignId/agreements/_put/index.ts
@@ -32,7 +32,7 @@ export default class RouteItem extends CampaignRoute<{
       agreementId <= 0 ||
       !Number.isInteger(agreementId) ||
       typeof tokens !== "number" ||
-      tokens <= 0
+      tokens < 0
     ) {
       return true;
     }


### PR DESCRIPTION
This pull request updates the `PUT /dossiers/:id/agreements` endpoint to allow setting the `tokens` value to zero, and adds a corresponding test to ensure this behavior is handled correctly. The main changes are:

Validation logic update:

* Modified the validation in `RouteItem` to allow `tokens` to be zero, only rejecting negative values instead of non-positive values. This enables setting `tokens` to zero via the API.

Testing improvements:

* Added a test case to verify that updating `tokens` to zero is accepted and correctly updates the database, with the endpoint returning a 200 status.