### PR TITLE
release-20260126

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        run: | 
+        run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm ci
       - name: "Run Test"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@appquality/tryber-database": "^0.46.9",
+        "@appquality/tryber-database": "^0.46.11",
         "@appquality/wp-auth": "^1.0.7",
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/hash-node": "^3.374.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@appquality/tryber-database": "^0.46.9",
+    "@appquality/tryber-database": "^0.46.11",
     "@appquality/wp-auth": "^1.0.7",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/hash-node": "^3.374.0",

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -6048,6 +6048,7 @@ paths:
                     - string
                   notes: string
                   notify_everyone: 0
+                  ux_notify: 1
                   outOfScope: string
                   productLink: string
                   productType: 0
@@ -6068,8 +6069,10 @@ paths:
             schema:
               allOf:
                 - $ref: '#/components/schemas/DossierCreationData'
-                - properties:
+                - type: object
+                  properties:
                     duplicate:
+                      type: object
                       properties:
                         campaign:
                           type: integer
@@ -6083,9 +6086,8 @@ paths:
                           type: integer
                         useCases:
                           type: integer
-                      type: object
-                  type: object
-                - properties:
+                - type: object
+                  properties:
                     autoApply:
                       maximum: 1
                       minimum: 0
@@ -6115,14 +6117,20 @@ paths:
                       maximum: 1
                       minimum: 0
                       type: integer
-                  type: object
-                - properties:
+                - type: object
+                  properties:
                     notify_everyone:
                       default: 0
                       enum:
                         - 0
                         - 1
-                  type: object
+                    ux_notify:
+                      type: integer
+                      x-stoplight:
+                        id: 0gogh4w9jbf6i
+                      minimum: 0
+                      maximum: 1
+                      example: 1
       responses:
         '201':
           content:

--- a/src/routes/dossiers/_post/creation.spec.ts
+++ b/src/routes/dossiers/_post/creation.spec.ts
@@ -1362,5 +1362,32 @@ describe("Route POST /dossiers", () => {
         ])
       );
     });
+
+    it("Should insert send_ux_notification = 1 if ux_notify = 1 is passed", async () => {
+      const postResponse = await request(app)
+        .post("/dossiers")
+        .set("authorization", "Bearer admin")
+        .send({ ...baseRequest, ux_notify: 1 });
+
+      const data = await tryber.tables.WpAppqEvdCampaign.do()
+        .select("send_ux_notification")
+        .where({ id: postResponse.body.id })
+        .first();
+
+      expect(data).toHaveProperty("send_ux_notification", 1);
+    });
+
+    it("Should insert send_ux_notification = 0 if ux_notify is not passed", async () => {
+      const postResponse = await request(app)
+        .post("/dossiers")
+        .set("authorization", "Bearer admin")
+        .send({ ...baseRequest });
+      const data = await tryber.tables.WpAppqEvdCampaign.do()
+        .select("send_ux_notification")
+        .where({ id: postResponse.body.id })
+        .first();
+
+      expect(data).toHaveProperty("send_ux_notification", 0);
+    });
   });
 });

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -106,6 +106,8 @@ export default class PostDossiers extends UserRoute<{
     const { skipPagesAndTasks, bugLanguage, notify_everyone, ux_notify } =
       this.getBody();
 
+    console.debug("Creating campaign with body:", this.getBody());
+
     try {
       const campaignId = await this.createCampaign();
       await this.linkRolesToCampaign(campaignId);

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -903,7 +903,7 @@ export default class PostDossiers extends UserRoute<{
     try {
       await tryber.tables.WpAppqEvdCampaign.do()
         .update({
-          send_ux_notifications: 1,
+          send_ux_notification: 1,
         })
         .where("id", campaignId);
     } catch (error) {

--- a/src/routes/dossiers/_post/index.ts
+++ b/src/routes/dossiers/_post/index.ts
@@ -103,7 +103,8 @@ export default class PostDossiers extends UserRoute<{
   }
 
   protected async prepare(): Promise<void> {
-    const { skipPagesAndTasks, bugLanguage, notify_everyone } = this.getBody();
+    const { skipPagesAndTasks, bugLanguage, notify_everyone, ux_notify } =
+      this.getBody();
 
     try {
       const campaignId = await this.createCampaign();
@@ -119,6 +120,10 @@ export default class PostDossiers extends UserRoute<{
 
       if (notify_everyone === 1) {
         await this.setupNotifications(campaignId);
+      }
+
+      if (ux_notify === 1) {
+        await this.enableUXTaskNotifications(campaignId);
       }
 
       const webhook = new WebhookTrigger({
@@ -890,6 +895,19 @@ export default class PostDossiers extends UserRoute<{
       );
       // @ts-ignore
       console.error("Error details: ", error?.response?.data);
+      return;
+    }
+  }
+
+  private async enableUXTaskNotifications(campaignId: number) {
+    try {
+      await tryber.tables.WpAppqEvdCampaign.do()
+        .update({
+          send_ux_notifications: 1,
+        })
+        .where("id", campaignId);
+    } catch (error) {
+      console.error("Error enabling UX task notifications:", error);
       return;
     }
   }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2994,6 +2994,8 @@ export interface operations {
         } & {
           /** @enum {undefined} */
           notify_everyone?: 0 | 1;
+          /** @example 1 */
+          ux_notify?: number;
         };
       };
     };


### PR DESCRIPTION
This pull request introduces support for a new `ux_notify` field when creating dossiers (campaigns), allowing the API to trigger UX task notifications as part of the campaign creation process. The change is reflected across the API schema, OpenAPI documentation, backend logic, and tests to ensure correct handling and documentation of this new field.

**API and Schema Updates:**

- Added the `ux_notify` field to the dossier creation API schema and OpenAPI documentation, including its type, example, and constraints. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR6051) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dL6118-R6133) [[3]](diffhunk://#diff-1b1f8e32f0a3581b6418901d5ef0e1de13b840515925f11e9ada1a2b4693149bR2997-R2998)

**Backend Logic:**

- Updated the dossier creation route (`PostDossiers`) to read the `ux_notify` field from the request body and, if set to `1`, call a new method to enable UX task notifications for the created campaign. [[1]](diffhunk://#diff-9160cbac51b6b28e78595b56aa9315f52d1f50a398341a26cc6e6e7cf1a77864L106-R109) [[2]](diffhunk://#diff-9160cbac51b6b28e78595b56aa9315f52d1f50a398341a26cc6e6e7cf1a77864R127-R130)
- Implemented the `enableUXTaskNotifications` method to update the `send_ux_notification` column in the `WpAppqEvdCampaign` table.

**Testing:**

- Added tests to verify that passing `ux_notify = 1` sets `send_ux_notification` to `1` in the database, and that omitting the field defaults it to `0`.

**Dependency Update:**

- Updated the `@appquality/tryber-database` dependency to version `^0.46.11` in `package.json`.