### PR TITLE
UN-2277 get other costs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@appquality/tryber-database": "^0.46.17",
+        "@appquality/tryber-database": "^0.46.18",
         "@appquality/wp-auth": "^1.0.7",
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/hash-node": "^3.374.0",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@appquality/tryber-database": {
-      "version": "0.46.17",
-      "resolved": "https://registry.npmjs.org/@appquality/tryber-database/-/tryber-database-0.46.17.tgz",
-      "integrity": "sha512-pipi0ypxbkSqkGD69yEx/6M8yYkd3uCevS0Gw7tc97MieSgsGU75X/CIBF7Adr04xbk1tPMLIS7uZ9Q+nJ10vQ==",
+      "version": "0.46.18",
+      "resolved": "https://registry.npmjs.org/@appquality/tryber-database/-/tryber-database-0.46.18.tgz",
+      "integrity": "sha512-7G9GIX3gpWCJJpo/DgdrSXRu/Jm/MJnbhglT9q0SoemEQQPZwSREFnxbGXxqg77URTeG7iNHXRzH1DXSkCVmSg==",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^12.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@appquality/tryber-database": "^0.46.17",
+    "@appquality/tryber-database": "^0.46.18",
     "@appquality/wp-auth": "^1.0.7",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/hash-node": "^3.374.0",

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13413,17 +13413,26 @@ paths:
                       x-stoplight:
                         id: r1p9rcymebjpu
                       type: object
+                      required:
+                        - name
+                        - id
                       properties:
                         name:
                           type: string
                           x-stoplight:
                             id: y0keeoutvijjh
+                        id:
+                          type: number
+                          x-stoplight:
+                            id: r546xns1ecc4j
               examples:
                 Example 1:
                   value:
                     items:
                       - name: Recruiting
+                        id: 1
                       - name: Survey
+                        id: 2
         '403':
           $ref: '#/components/responses/NotAuthorized'
         '404':

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13429,10 +13429,38 @@ paths:
     get:
       summary: Your GET endpoint
       tags: []
-      responses: {}
+      responses:
+        '200':
+          description: OK
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    x-stoplight:
+                      id: 7k2qykvqlzwfe
+                    items:
+                      x-stoplight:
+                        id: srl106ylr6cpm
+                      type: object
+                      properties:
+                        type:
+                          type: object
+                          x-stoplight:
+                            id: itchthltx575n
       operationId: get-campaigns-campaign-finance-otherCosts
       x-stoplight:
         id: 9hp8r67rwl59d
+      security:
+        - JWT: []
 servers:
   - url: 'https://api.app-quality.com'
 tags:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13452,10 +13452,77 @@ paths:
                         id: srl106ylr6cpm
                       type: object
                       properties:
+                        cost_id:
+                          type: number
+                          x-stoplight:
+                            id: 5tq4npphsv3wx
                         type:
                           type: object
                           x-stoplight:
                             id: itchthltx575n
+                          properties:
+                            name:
+                              type: string
+                              x-stoplight:
+                                id: mkzkmmdtonn2u
+                            id:
+                              type: number
+                              x-stoplight:
+                                id: ng1a3g0fc695g
+                        supplier:
+                          type: object
+                          x-stoplight:
+                            id: pewi2gjqq2j1h
+                          properties:
+                            name:
+                              type: string
+                              x-stoplight:
+                                id: eel1e2x9tsc4x
+                            id:
+                              type: number
+                              x-stoplight:
+                                id: ppawzunmvk3qx
+                        description:
+                          type: string
+                          x-stoplight:
+                            id: jlosijekgy2c6
+                        attachments:
+                          type: array
+                          x-stoplight:
+                            id: jj9p1k4imekme
+                          items:
+                            x-stoplight:
+                              id: w31uej26rl532
+                            type: object
+                            properties:
+                              id:
+                                type: number
+                                x-stoplight:
+                                  id: bz8ydut5na834
+                              url:
+                                type: string
+                                x-stoplight:
+                                  id: nctzb7saomq7c
+                              mimetype:
+                                type: string
+                                x-stoplight:
+                                  id: 6tqj2cg96280v
+              examples:
+                Example 1:
+                  value:
+                    items:
+                      - type:
+                          name: string
+                          id: 0
+                        supplier:
+                          name: string
+                          id: 0
+                        description: string
+                        attachments:
+                          - id: 0
+                            url: string
+                            mimetype: string
+                        cost_id: 0
       operationId: get-campaigns-campaign-finance-otherCosts
       x-stoplight:
         id: 9hp8r67rwl59d

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13419,6 +13419,20 @@ paths:
         id: 02e8ns5xdhecm
       security:
         - JWT: []
+  '/campaigns/{campaign}/finance/otherCosts':
+    parameters:
+      - schema:
+          type: string
+        name: campaign
+        in: path
+        required: true
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses: {}
+      operationId: get-campaigns-campaign-finance-otherCosts
+      x-stoplight:
+        id: 9hp8r67rwl59d
 servers:
   - url: 'https://api.app-quality.com'
 tags:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13432,12 +13432,6 @@ paths:
       responses:
         '200':
           description: OK
-        '403':
-          description: Forbidden
-        '404':
-          description: Not Found
-        '500':
-          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -13523,6 +13517,13 @@ paths:
                             url: string
                             mimetype: string
                         cost_id: 0
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal Server Error
+         
       operationId: get-campaigns-campaign-finance-otherCosts
       x-stoplight:
         id: 9hp8r67rwl59d

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13299,6 +13299,7 @@ paths:
                       type: object
                       required:
                         - name
+                        - id
                       properties:
                         name:
                           type: string
@@ -13312,11 +13313,16 @@ paths:
                           type: integer
                           x-stoplight:
                             id: gcs2p8mvl32gc
+                        id:
+                          type: number
+                          x-stoplight:
+                            id: ek7zfipegepg5
               examples:
                 Example 2:
                   value:
                     items:
-                      - name: Respondent
+                      - id: 1
+                        name: Respondent
                         created_at: '2026-01-01'
                         created_by: 10
         '400':
@@ -13344,7 +13350,17 @@ paths:
       responses:
         '201':
           description: Created
-          content: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - supplier_id
+                properties:
+                  supplier_id:
+                    type: number
+                    x-stoplight:
+                      id: rsrwvlerw0w2j
         '400':
           description: Bad Request
         '403':
@@ -13523,7 +13539,6 @@ paths:
           description: Not Found
         '500':
           description: Internal Server Error
-         
       operationId: get-campaigns-campaign-finance-otherCosts
       x-stoplight:
         id: 9hp8r67rwl59d

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
@@ -97,21 +97,21 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
     await tryber.tables.WpAppqCampaignOtherCostsAttachment.do().insert([
       {
         id: 1,
-        cost_id: 1,
         url: "https://example.com/attachment1.pdf",
         mime_type: "application/pdf",
+        cost_id: 1,
       },
       {
         id: 2,
-        cost_id: 1,
         url: "https://example.com/attachment2.jpg",
         mime_type: "image/jpeg",
+        cost_id: 1,
       },
       {
         id: 3,
-        cost_id: 2,
         url: "https://example.com/attachment3.png",
         mime_type: "image/png",
+        cost_id: 2,
       },
     ]);
   });

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
@@ -1,0 +1,305 @@
+import request from "supertest";
+import app from "@src/app";
+import { tryber } from "@src/features/database";
+
+describe("GET /campaigns/campaignId/finance/otherCosts", () => {
+  beforeAll(async () => {
+    await tryber.tables.WpAppqEvdProfile.do().insert([
+      {
+        id: 1,
+        name: "John",
+        surname: "Doe",
+        wp_user_id: 1,
+        email: "",
+        employment_id: 1,
+        education_id: 1,
+      },
+    ]);
+    await tryber.tables.WpUsers.do().insert({ ID: 1 });
+    await tryber.tables.WpAppqEvdCampaign.do().insert([
+      {
+        id: 1,
+        platform_id: 1,
+        start_date: "2020-01-01",
+        end_date: "2020-01-01",
+        title: "This is the title",
+        page_preview_id: 1,
+        page_manual_id: 1,
+        customer_id: 1,
+        pm_id: 1,
+        project_id: 1,
+        customer_title: "",
+      },
+      {
+        id: 2,
+        platform_id: 1,
+        start_date: "2020-01-01",
+        end_date: "2020-01-01",
+        title: "Another campaign",
+        page_preview_id: 1,
+        page_manual_id: 1,
+        customer_id: 1,
+        pm_id: 1,
+        project_id: 1,
+        customer_title: "",
+      },
+    ]);
+    await tryber.tables.WpAppqCampaignOtherCostsType.do().insert([
+      {
+        id: 1,
+        name: "Type 1",
+      },
+      {
+        id: 2,
+        name: "Type 2",
+      },
+    ]);
+    await tryber.tables.WpAppqCampaignOtherCostsSupplier.do().insert([
+      {
+        id: 1,
+        name: "Supplier 1",
+        created_by: 1,
+        created_on: "2024-01-01 10:00:00",
+      },
+      {
+        id: 2,
+        name: "Supplier 2",
+        created_by: 1,
+        created_on: "2024-01-02 11:00:00",
+      },
+    ]);
+    await tryber.tables.WpAppqCampaignOtherCosts.do().insert([
+      {
+        id: 1,
+        campaign_id: 1,
+        description: "Cost 1 description",
+        cost: 100.5,
+        type_id: 1,
+        supplier_id: 1,
+      },
+      {
+        id: 2,
+        campaign_id: 1,
+        description: "Cost 2 description",
+        cost: 200.75,
+        type_id: 2,
+        supplier_id: 2,
+      },
+      {
+        id: 3,
+        campaign_id: 2,
+        description: "Cost for other campaign",
+        cost: 150.0,
+        type_id: 1,
+        supplier_id: 1,
+      },
+    ]);
+    await tryber.tables.WpAppqCampaignOtherCostsAttachment.do().insert([
+      {
+        id: 1,
+        cost_id: 1,
+        url: "https://example.com/attachment1.pdf",
+        mime_type: "application/pdf",
+      },
+      {
+        id: 2,
+        cost_id: 1,
+        url: "https://example.com/attachment2.jpg",
+        mime_type: "image/jpeg",
+      },
+      {
+        id: 3,
+        cost_id: 2,
+        url: "https://example.com/attachment3.png",
+        mime_type: "image/png",
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await tryber.tables.WpAppqCampaignOtherCostsAttachment.do().delete();
+    await tryber.tables.WpAppqCampaignOtherCosts.do().delete();
+    await tryber.tables.WpAppqCampaignOtherCostsSupplier.do().delete();
+    await tryber.tables.WpAppqCampaignOtherCostsType.do().delete();
+    await tryber.tables.WpAppqEvdCampaign.do().delete();
+    await tryber.tables.WpUsers.do().delete();
+    await tryber.tables.WpAppqEvdProfile.do().delete();
+  });
+
+  it("Should return 403 if logged out", async () => {
+    const response = await request(app).get("/campaigns/1/finance/otherCosts");
+    expect(response.status).toBe(403);
+  });
+
+  it("Should return 403 if logged in as not admin user", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", "Bearer tester");
+    expect(response.status).toBe(403);
+  });
+
+  it("Should return 403 if no access to the campaign", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", 'Bearer tester"');
+    expect(response.status).toBe(403);
+  });
+
+  it("Should return 200 if logged in as admin", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", "Bearer admin");
+    expect(response.status).toBe(200);
+  });
+
+  it("Should return finance other costs - admin", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", "Bearer admin");
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            cost_id: 1,
+            type: {
+              name: "Type 1",
+              id: 1,
+            },
+            supplier: {
+              name: "Supplier 1",
+              id: 1,
+            },
+            description: "Cost 1 description",
+            attachments: expect.arrayContaining([
+              expect.objectContaining({
+                id: 1,
+                url: "https://example.com/attachment1.pdf",
+                mimetype: "application/pdf",
+              }),
+              expect.objectContaining({
+                id: 2,
+                url: "https://example.com/attachment2.jpg",
+                mimetype: "image/jpeg",
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            cost_id: 2,
+            type: {
+              name: "Type 2",
+              id: 2,
+            },
+            supplier: {
+              name: "Supplier 2",
+              id: 2,
+            },
+            description: "Cost 2 description",
+            attachments: expect.arrayContaining([
+              expect.objectContaining({
+                id: 3,
+                url: "https://example.com/attachment3.png",
+                mimetype: "image/png",
+              }),
+            ]),
+          }),
+        ]),
+      })
+    );
+    expect(response.body.items).toHaveLength(2);
+  });
+
+  it("Should return other costs - olp permissions", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            cost_id: 1,
+            type: {
+              name: "Type 1",
+              id: 1,
+            },
+            supplier: {
+              name: "Supplier 1",
+              id: 1,
+            },
+            description: "Cost 1 description",
+          }),
+          expect.objectContaining({
+            cost_id: 2,
+            type: {
+              name: "Type 2",
+              id: 2,
+            },
+            supplier: {
+              name: "Supplier 2",
+              id: 2,
+            },
+            description: "Cost 2 description",
+          }),
+        ]),
+      })
+    );
+    expect(response.body.items).toHaveLength(2);
+  });
+
+  it("Should return empty items array if no costs exist for campaign", async () => {
+    await tryber.tables.WpAppqEvdCampaign.do().insert({
+      id: 99,
+      platform_id: 1,
+      start_date: "2020-01-01",
+      end_date: "2020-01-01",
+      title: "Campaign with no costs",
+      page_preview_id: 1,
+      page_manual_id: 1,
+      customer_id: 1,
+      pm_id: 1,
+      project_id: 1,
+      customer_title: "",
+    });
+
+    const response = await request(app)
+      .get("/campaigns/99/finance/otherCosts")
+      .set("Authorization", "Bearer admin");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      items: [],
+    });
+  });
+
+  it("Should not include costs from other campaigns", async () => {
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", "Bearer admin");
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(2);
+    expect(
+      response.body.items.find((item: any) => item.cost_id === 3)
+    ).toBeUndefined();
+  });
+
+  it("Should return cost with empty attachments array if cost has no attachments", async () => {
+    await tryber.tables.WpAppqCampaignOtherCosts.do().insert({
+      id: 10,
+      campaign_id: 1,
+      description: "Cost without attachments",
+      cost: 50.0,
+      type_id: 1,
+      supplier_id: 1,
+    });
+
+    const response = await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", "Bearer admin");
+    expect(response.status).toBe(200);
+
+    const costWithoutAttachments = response.body.items.find(
+      (item: any) => item.cost_id === 10
+    );
+    expect(costWithoutAttachments).toBeDefined();
+    expect(costWithoutAttachments.attachments).toEqual([]);
+  });
+});

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
@@ -1,0 +1,104 @@
+/** OPENAPI-CLASS: get-campaigns-campaign-finance-otherCosts */
+
+import CampaignRoute from "@src/features/routes/CampaignRoute";
+import { tryber } from "@src/features/database";
+import OpenapiError from "@src/features/OpenapiError";
+
+type OtherCost = {
+  cost_id: number;
+  type: {
+    name: string;
+    id: number;
+  };
+  supplier: {
+    name: string;
+    id: number;
+  };
+  description: string;
+  attachments: {
+    id: number;
+    url: string;
+    mimetype: string;
+  }[];
+};
+
+export default class OtherCostsRoute extends CampaignRoute<{
+  response: StoplightOperations["get-campaigns-campaign-finance-otherCosts"]["responses"]["200"]["content"]["application/json"];
+  parameters: StoplightOperations["get-campaigns-campaign-finance-otherCosts"]["parameters"]["path"];
+}> {
+  protected async filter(): Promise<boolean> {
+    if (!(await super.filter())) return false;
+
+    if (!this.hasAccessToCampaign(this.cp_id)) {
+      this.setError(403, new OpenapiError("Access denied"));
+
+      return false;
+    }
+    return true;
+  }
+
+  protected async prepare(): Promise<void> {
+    const costs = await this.getOtherCosts();
+
+    return this.setSuccess(200, { items: costs });
+  }
+
+  private async getOtherCosts(): Promise<OtherCost[]> {
+    const costs = await tryber.tables.WpAppqCampaignOtherCosts.do()
+      .select(
+        tryber
+          .ref("id")
+          .withSchema("wp_appq_campaign_other_costs")
+          .as("cost_id"),
+        "description",
+        "type_id",
+        "supplier_id"
+      )
+      .where("campaign_id", this.cp_id);
+
+    if (!costs.length) return [];
+
+    const typeIds = [...new Set(costs.map((c) => c.type_id))];
+    const supplierIds = [...new Set(costs.map((c) => c.supplier_id))];
+    const costIds = costs.map((c) => c.cost_id);
+
+    const types = await tryber.tables.WpAppqCampaignOtherCostsType.do()
+      .select("id", "name")
+      .whereIn("id", typeIds);
+
+    const suppliers = await tryber.tables.WpAppqCampaignOtherCostsSupplier.do()
+      .select("id", "name")
+      .whereIn("id", supplierIds);
+
+    const attachments =
+      await tryber.tables.WpAppqCampaignOtherCostsAttachment.do()
+        .select("id", "url", "mime_type", "cost_id")
+        .whereIn("cost_id", costIds);
+
+    return costs.map((cost) => {
+      const type = types.find((t) => t.id === cost.type_id);
+      const supplier = suppliers.find((s) => s.id === cost.supplier_id);
+      const costAttachments = attachments.filter(
+        (a) => a.cost_id === cost.cost_id
+      );
+
+      return {
+        cost_id: cost.cost_id,
+        type: {
+          name: type?.name || "",
+          id: type?.id || 0,
+        },
+        supplier: {
+          name: supplier?.name || "",
+          id: supplier?.id || 0,
+        },
+        description: cost.description,
+        attachments: costAttachments.map((a) => ({
+          id: a.id,
+          url: a.url,
+          mimetype: a.mime_type,
+        })),
+      };
+    });
+  }
+}

--- a/src/routes/campaigns/campaignId/finance/supplier/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/supplier/_get/index.spec.ts
@@ -95,11 +95,13 @@ describe("GET /campaigns/campaignId/finance/supplier", () => {
       expect.objectContaining({
         items: expect.arrayContaining([
           expect.objectContaining({
+            id: 1,
             name: "Supplier 1",
             created_by: 1,
             created_on: "2024-01-01 10:00:00",
           }),
           expect.objectContaining({
+            id: 2,
             name: "Supplier 2",
             created_by: 2,
             created_on: "2024-01-02 11:00:00",
@@ -119,11 +121,13 @@ describe("GET /campaigns/campaignId/finance/supplier", () => {
       expect.objectContaining({
         items: expect.arrayContaining([
           expect.objectContaining({
+            id: 1,
             name: "Supplier 1",
             created_by: 1,
             created_on: "2024-01-01 10:00:00",
           }),
           expect.objectContaining({
+            id: 2,
             name: "Supplier 2",
             created_by: 2,
             created_on: "2024-01-02 11:00:00",

--- a/src/routes/campaigns/campaignId/finance/supplier/_get/index.ts
+++ b/src/routes/campaigns/campaignId/finance/supplier/_get/index.ts
@@ -5,6 +5,7 @@ import { tryber } from "@src/features/database";
 import OpenapiError from "@src/features/OpenapiError";
 
 type Supplier = {
+  id: number;
   name: string;
   created_on?: string;
   created_by?: number;
@@ -33,6 +34,7 @@ export default class SupplierRoute extends CampaignRoute<{
 
   private async getSuppliers(): Promise<Supplier[]> {
     return await tryber.tables.WpAppqCampaignOtherCostsSupplier.do().select(
+      "id",
       "name",
       "created_on",
       "created_by"

--- a/src/routes/campaigns/campaignId/finance/supplier/_post/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/supplier/_post/index.spec.ts
@@ -101,6 +101,7 @@ describe("POST /campaigns/campaignId/finance/supplier", () => {
         .send({ name: "New Supplier" })
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(201);
+      expect(response.body).toEqual({ supplier_id: expect.any(Number) });
     });
     it("Should not add existing supplier", async () => {
       const response = await request(app)
@@ -131,6 +132,7 @@ describe("POST /campaigns/campaignId/finance/supplier", () => {
         .send({ name: "New Supplier" })
         .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
       expect(response.status).toBe(201);
+      expect(response.body).toEqual({ supplier_id: expect.any(Number) });
     });
 
     it("Should not add existing supplier", async () => {

--- a/src/routes/campaigns/campaignId/finance/type/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/type/_get/index.spec.ts
@@ -82,9 +82,11 @@ describe("GET /campaigns/campaignId/finance/type", () => {
       expect.objectContaining({
         items: expect.arrayContaining([
           expect.objectContaining({
+            id: 1,
             name: "Type 1",
           }),
           expect.objectContaining({
+            id: 2,
             name: "Type 2",
           }),
         ]),
@@ -102,9 +104,11 @@ describe("GET /campaigns/campaignId/finance/type", () => {
       expect.objectContaining({
         items: expect.arrayContaining([
           expect.objectContaining({
+            id: 1,
             name: "Type 1",
           }),
           expect.objectContaining({
+            id: 2,
             name: "Type 2",
           }),
         ]),

--- a/src/routes/campaigns/campaignId/finance/type/_get/index.ts
+++ b/src/routes/campaigns/campaignId/finance/type/_get/index.ts
@@ -26,6 +26,9 @@ export default class TypeRoute extends CampaignRoute<{
   }
 
   private async getTypes() {
-    return await tryber.tables.WpAppqCampaignOtherCostsType.do().select("name");
+    return await tryber.tables.WpAppqCampaignOtherCostsType.do().select(
+      "name",
+      "id"
+    );
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5555,6 +5555,7 @@ export interface operations {
               name: string;
               created_at?: string;
               created_by?: number;
+              id: number;
             }[];
           };
         };
@@ -5575,7 +5576,13 @@ export interface operations {
     };
     responses: {
       /** Created */
-      201: unknown;
+      201: {
+        content: {
+          "application/json": {
+            supplier_id: number;
+          };
+        };
+      };
       /** Bad Request */
       400: unknown;
       /** Forbidden */

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5610,7 +5610,8 @@ export interface operations {
         content: {
           "application/json": {
             items: {
-              name?: string;
+              name: string;
+              id: number;
             }[];
           };
         };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -822,6 +822,14 @@ export interface paths {
       };
     };
   };
+  "/campaigns/{campaign}/finance/otherCosts": {
+    get: operations["get-campaigns-campaign-finance-otherCosts"];
+    parameters: {
+      path: {
+        campaign: string;
+      };
+    };
+  };
 }
 
 export interface components {
@@ -5604,6 +5612,45 @@ export interface operations {
       404: components["responses"]["NotFound"];
       /** Internal Server Error */
       500: unknown;
+    };
+  };
+  "get-campaigns-campaign-finance-otherCosts": {
+    parameters: {
+      path: {
+        campaign: string;
+      };
+    };
+    responses: {
+      /** OK */
+      200: unknown;
+      /** Forbidden */
+      403: unknown;
+      /** Not Found */
+      404: unknown;
+      /** Internal Server Error */
+      500: {
+        content: {
+          "application/json": {
+            items?: {
+              cost_id?: number;
+              type?: {
+                name?: string;
+                id?: number;
+              };
+              supplier?: {
+                name?: string;
+                id?: number;
+              };
+              description?: string;
+              attachments?: {
+                id?: number;
+                url?: string;
+                mimetype?: string;
+              }[];
+            }[];
+          };
+        };
+      };
     };
   };
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5622,13 +5622,7 @@ export interface operations {
     };
     responses: {
       /** OK */
-      200: unknown;
-      /** Forbidden */
-      403: unknown;
-      /** Not Found */
-      404: unknown;
-      /** Internal Server Error */
-      500: {
+      200: {
         content: {
           "application/json": {
             items?: {
@@ -5651,6 +5645,12 @@ export interface operations {
           };
         };
       };
+      /** Forbidden */
+      403: unknown;
+      /** Not Found */
+      404: unknown;
+      /** Internal Server Error */
+      500: unknown;
     };
   };
 }


### PR DESCRIPTION
This pull request introduces a new endpoint for retrieving "other costs" associated with a campaign, refines the supplier endpoints to include supplier IDs, and updates the OpenAPI specification and tests to reflect these changes. The most significant updates are the addition of the `/campaigns/{campaign}/finance/otherCosts` GET endpoint, improvements in supplier data handling, and enhanced OpenAPI documentation.

**New "Other Costs" Endpoint:**

* Added the `GET /campaigns/{campaign}/finance/otherCosts` endpoint, including its implementation (`_get/index.ts`) and a comprehensive test suite. This endpoint returns detailed information about other costs for a campaign, including type, supplier, description, and attachments. [[1]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabR1-R104) [[2]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR1-R305) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13447-R13555)

**Supplier Endpoint Improvements:**

* Updated supplier endpoints and tests to include the `id` property in supplier objects, ensuring supplier IDs are returned in API responses and are properly tested. [[1]](diffhunk://#diff-dbeaab68b141736fbc15266b3af85e34b3e0a96783f41c41caa4a39b3da823e6R98-R104) [[2]](diffhunk://#diff-dbeaab68b141736fbc15266b3af85e34b3e0a96783f41c41caa4a39b3da823e6R124-R130) [[3]](diffhunk://#diff-5bdaac035e138185c7b764b666b2cf35da957162152530ee33844427fa2d7149R8) [[4]](diffhunk://#diff-5bdaac035e138185c7b764b666b2cf35da957162152530ee33844427fa2d7149R37)

**OpenAPI Specification Updates:**

* Modified the OpenAPI spec to require and document the `id` property for suppliers and other cost types, and updated example responses accordingly. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13302) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13316-R13325) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13416-R13435)
* Updated the POST supplier response schema to return a `supplier_id` in the response and adjusted related tests. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dL13347-R13363) [[2]](diffhunk://#diff-2401ca210445ea47269a216cc3a136f341f1d62df2c356255a810effb9f085aaL8-R8) [[3]](diffhunk://#diff-3efcd51ffac5a4343bb733bf9c7da0ae47f7a5a505e1961a06745dd0071243afR104) [[4]](diffhunk://#diff-3efcd51ffac5a4343bb733bf9c7da0ae47f7a5a505e1961a06745dd0071243afR135)

These changes collectively improve the API's consistency, add new functionality for financial data retrieval, and ensure that both documentation and tests accurately reflect the updated behavior.