### PR TITLE
Update get other costs

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13462,6 +13462,8 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - items
                 properties:
                   items:
                     type: array
@@ -13471,6 +13473,13 @@ paths:
                       x-stoplight:
                         id: srl106ylr6cpm
                       type: object
+                      required:
+                        - cost_id
+                        - type
+                        - supplier
+                        - description
+                        - attachments
+                        - cost
                       properties:
                         cost_id:
                           type: number
@@ -13480,6 +13489,9 @@ paths:
                           type: object
                           x-stoplight:
                             id: itchthltx575n
+                          required:
+                            - name
+                            - id
                           properties:
                             name:
                               type: string
@@ -13493,6 +13505,9 @@ paths:
                           type: object
                           x-stoplight:
                             id: pewi2gjqq2j1h
+                          required:
+                            - name
+                            - id
                           properties:
                             name:
                               type: string
@@ -13514,6 +13529,10 @@ paths:
                             x-stoplight:
                               id: w31uej26rl532
                             type: object
+                            required:
+                              - id
+                              - url
+                              - mimetype
                             properties:
                               id:
                                 type: number
@@ -13527,6 +13546,10 @@ paths:
                                 type: string
                                 x-stoplight:
                                   id: 6tqj2cg96280v
+                        cost:
+                          type: number
+                          x-stoplight:
+                            id: 4zut3xli3ht5f
               examples:
                 Example 1:
                   value:
@@ -13543,6 +13566,7 @@ paths:
                             url: string
                             mimetype: string
                         cost_id: 0
+                        cost: 10.2
         '403':
           description: Forbidden
         '404':

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
@@ -161,6 +161,7 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
         items: expect.arrayContaining([
           expect.objectContaining({
             cost_id: 1,
+            cost: 100.5,
             type: {
               name: "Type 1",
               id: 1,
@@ -185,6 +186,7 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
           }),
           expect.objectContaining({
             cost_id: 2,
+            cost: 200.75,
             type: {
               name: "Type 2",
               id: 2,
@@ -218,6 +220,7 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
         items: expect.arrayContaining([
           expect.objectContaining({
             cost_id: 1,
+            cost: 100.5,
             type: {
               name: "Type 1",
               id: 1,
@@ -230,6 +233,7 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
           }),
           expect.objectContaining({
             cost_id: 2,
+            cost: 200.75,
             type: {
               name: "Type 2",
               id: 2,
@@ -300,6 +304,7 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
       (item: any) => item.cost_id === 10
     );
     expect(costWithoutAttachments).toBeDefined();
+    expect(costWithoutAttachments.cost).toBe(50);
     expect(costWithoutAttachments.attachments).toEqual([]);
   });
 });

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
@@ -6,6 +6,7 @@ import OpenapiError from "@src/features/OpenapiError";
 
 type OtherCost = {
   cost_id: number;
+  cost: number;
   type: {
     name: string;
     id: number;
@@ -52,7 +53,8 @@ export default class OtherCostsRoute extends CampaignRoute<{
           .as("cost_id"),
         "description",
         "type_id",
-        "supplier_id"
+        "supplier_id",
+        "cost"
       )
       .where("campaign_id", this.cp_id);
 
@@ -84,6 +86,7 @@ export default class OtherCostsRoute extends CampaignRoute<{
 
       return {
         cost_id: cost.cost_id,
+        cost: cost.cost,
         type: {
           name: type?.name || "",
           id: type?.id || 0,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5638,22 +5638,23 @@ export interface operations {
       200: {
         content: {
           "application/json": {
-            items?: {
-              cost_id?: number;
-              type?: {
-                name?: string;
-                id?: number;
+            items: {
+              cost_id: number;
+              type: {
+                name: string;
+                id: number;
               };
-              supplier?: {
-                name?: string;
-                id?: number;
+              supplier: {
+                name: string;
+                id: number;
               };
-              description?: string;
-              attachments?: {
-                id?: number;
-                url?: string;
-                mimetype?: string;
+              description: string;
+              attachments: {
+                id: number;
+                url: string;
+                mimetype: string;
               }[];
+              cost: number;
             }[];
           };
         };


### PR DESCRIPTION
This pull request adds a required `cost` field to the "other costs" API and ensures that several fields are now required in both the OpenAPI specification and the TypeScript types. It also updates the backend logic and tests to include and validate the new `cost` field for each item.

**API and Schema Updates:**

* Made `items` a required property in the response schema for the relevant endpoint in `openapi.yml`, and marked several fields (including `cost`, `cost_id`, `type`, `supplier`, `description`, `attachments`) as required for each item. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13465-R13466) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13476-R13482)
* Added the `cost` field as a required number property for each cost item in both the OpenAPI schema and the generated TypeScript types, and updated the response examples accordingly. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13549-R13552) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13569) [[3]](diffhunk://#diff-1b1f8e32f0a3581b6418901d5ef0e1de13b840515925f11e9ada1a2b4693149bL5641-R5657)

**Backend and Type Updates:**

* Updated the `OtherCost` type and the backend route handler to include and return the new `cost` field for each cost item. [[1]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabR9) [[2]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabL55-R57) [[3]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabR89)

**Test Updates:**

* Updated tests to expect the `cost` field in all relevant assertions for returned cost items. [[1]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR164) [[2]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR189) [[3]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR223) [[4]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR236) [[5]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR307)

**Other Schema Improvements:**

* Marked `name` and `id` as required for nested `type` and `supplier` objects, and made `id`, `url`, and `mimetype` required for `attachments`. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13492-R13494) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13508-R13510) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13532-R13535)