### PR TITLE
Other costs accept array

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13600,57 +13600,59 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              x-examples:
-                Example 1:
-                  description: Riparazione hardware ufficio
-                  type_id: 3
-                  supplier_id: 105
-                  cost: 250.5
+              type: array
+              items:
+                type: object
+                x-examples:
+                  Example 1:
+                    description: Riparazione hardware ufficio
+                    type_id: 3
+                    supplier_id: 105
+                    cost: 250.5
+                    attachments:
+                      - url: 'https://esempio.com/documenti/fattura.pdf'
+                        mime_type: application/pdf
+                      - url: 'https://esempio.com/immagini/danno.jpg'
+                        mime_type: image/jpeg
+                required:
+                  - description
+                  - type_id
+                  - supplier_id
+                  - cost
+                  - attachments
+                properties:
+                  description:
+                    type: string
+                  type_id:
+                    type: integer
+                  supplier_id:
+                    type: integer
+                  cost:
+                    type: number
                   attachments:
-                    - url: 'https://esempio.com/documenti/fattura.pdf'
-                      mime_type: application/pdf
-                    - url: 'https://esempio.com/immagini/danno.jpg'
-                      mime_type: image/jpeg
-              required:
-                - description
-                - type_id
-                - supplier_id
-                - cost
-                - attachments
-              properties:
-                description:
-                  type: string
-                type_id:
-                  type: integer
-                supplier_id:
-                  type: integer
-                cost:
-                  type: number
-                attachments:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - url
-                      - mime_type
-                    properties:
-                      url:
-                        type: string
-                      mime_type:
-                        type: string
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - url
+                        - mime_type
+                      properties:
+                        url:
+                          type: string
+                        mime_type:
+                          type: string
             examples:
               Example 1:
                 value:
-                  description: Riparazione hardware ufficio
-                  type_id: 3
-                  supplier_id: 105
-                  cost: 250.5
-                  attachments:
-                    - url: 'https://esempio.com/documenti/fattura.pdf'
-                      mime_type: application/pdf
-                    - url: 'https://esempio.com/immagini/danno.jpg'
-                      mime_type: image/jpeg
+                  - description: Riparazione hardware ufficio
+                    type_id: 3
+                    supplier_id: 105
+                    cost: 250.5
+                    attachments:
+                      - url: 'https://esempio.com/documenti/fattura.pdf'
+                        mime_type: application/pdf
+                      - url: 'https://esempio.com/immagini/danno.jpg'
+                        mime_type: image/jpeg
       security:
         - JWT: []
     delete:
@@ -13697,64 +13699,66 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                x-examples:
-                  Example 1:
-                    description: Riparazione hardware ufficio
-                    type_id: 3
-                    cost_id: 2
-                    supplier_id: 105
-                    cost: 250.5
+                type: array
+                items:
+                  type: object
+                  x-examples:
+                    Example 1:
+                      description: Riparazione hardware ufficio
+                      type_id: 3
+                      cost_id: 2
+                      supplier_id: 105
+                      cost: 250.5
+                      attachments:
+                        - url: 'https://esempio.com/documenti/fattura.pdf'
+                          mime_type: application/pdf
+                        - url: 'https://esempio.com/immagini/danno.jpg'
+                          mime_type: image/jpeg
+                  required:
+                    - description
+                    - type
+                    - cost_id
+                    - supplier
+                    - cost
+                    - attachments
+                  properties:
+                    description:
+                      type: string
+                    type:
+                      type: string
+                      x-stoplight:
+                        id: q54ltj77jcyf0
+                    cost_id:
+                      type: integer
+                    supplier:
+                      type: string
+                      x-stoplight:
+                        id: 5aunsjh1dxfq1
+                    cost:
+                      type: number
                     attachments:
-                      - url: 'https://esempio.com/documenti/fattura.pdf'
-                        mime_type: application/pdf
-                      - url: 'https://esempio.com/immagini/danno.jpg'
-                        mime_type: image/jpeg
-                required:
-                  - description
-                  - type
-                  - cost_id
-                  - supplier
-                  - cost
-                  - attachments
-                properties:
-                  description:
-                    type: string
-                  type:
-                    type: string
-                    x-stoplight:
-                      id: q54ltj77jcyf0
-                  cost_id:
-                    type: integer
-                  supplier:
-                    type: string
-                    x-stoplight:
-                      id: 5aunsjh1dxfq1
-                  cost:
-                    type: number
-                  attachments:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                        - url
-                        - mime_type
-                      properties:
-                        url:
-                          type: string
-                        mime_type:
-                          type: string
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - url
+                          - mime_type
+                        properties:
+                          url:
+                            type: string
+                          mime_type:
+                            type: string
               examples:
                 Example 1:
                   value:
-                    description: description
-                    type: Type 1
-                    cost_id: 10
-                    supplier: Supplier
-                    cost: 104
-                    attachments:
-                      - url: 'https://example.com/'
-                        mime_type: image/jpg
+                    - description: description
+                      type: Type 1
+                      cost_id: 10
+                      supplier: Supplier
+                      cost: 104
+                      attachments:
+                        - url: 'https://example.com/'
+                          mime_type: image/jpg
         '400':
           description: Bad Request
         '403':
@@ -13772,63 +13776,65 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              x-examples:
-                Example 1:
-                  description: Riparazione hardware ufficio
-                  type_id: 3
-                  supplier_id: 105
-                  cost: 250.5
+              type: array
+              items:
+                type: object
+                x-examples:
+                  Example 1:
+                    description: Riparazione hardware ufficio
+                    type_id: 3
+                    supplier_id: 105
+                    cost: 250.5
+                    attachments:
+                      - url: 'https://esempio.com/documenti/fattura.pdf'
+                        mime_type: application/pdf
+                      - url: 'https://esempio.com/immagini/danno.jpg'
+                        mime_type: image/jpeg
+                required:
+                  - description
+                  - type_id
+                  - supplier_id
+                  - cost
+                  - attachments
+                  - cost_id
+                properties:
+                  description:
+                    type: string
+                  type_id:
+                    type: integer
+                  supplier_id:
+                    type: integer
+                  cost:
+                    type: number
                   attachments:
-                    - url: 'https://esempio.com/documenti/fattura.pdf'
-                      mime_type: application/pdf
-                    - url: 'https://esempio.com/immagini/danno.jpg'
-                      mime_type: image/jpeg
-              required:
-                - description
-                - type_id
-                - supplier_id
-                - cost
-                - attachments
-                - cost_id
-              properties:
-                description:
-                  type: string
-                type_id:
-                  type: integer
-                supplier_id:
-                  type: integer
-                cost:
-                  type: number
-                attachments:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - url
-                      - mime_type
-                    properties:
-                      url:
-                        type: string
-                      mime_type:
-                        type: string
-                cost_id:
-                  type: integer
-                  x-stoplight:
-                    id: drnv0dayw8k18
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - url
+                        - mime_type
+                      properties:
+                        url:
+                          type: string
+                        mime_type:
+                          type: string
+                  cost_id:
+                    type: integer
+                    x-stoplight:
+                      id: drnv0dayw8k18
             examples:
               Example 1:
                 value:
-                  description: Riparazione hardware ufficio
-                  type_id: 3
-                  cost_id: 2
-                  supplier_id: 105
-                  cost: 250.5
-                  attachments:
-                    - url: 'https://esempio.com/documenti/fattura.pdf'
-                      mime_type: application/pdf
-                    - url: 'https://esempio.com/immagini/danno.jpg'
-                      mime_type: image/jpeg
+                  - description: Riparazione hardware ufficio
+                    type_id: 3
+                    cost_id: 2
+                    supplier_id: 105
+                    cost: 250.5
+                    attachments:
+                      - url: 'https://esempio.com/documenti/fattura.pdf'
+                        mime_type: application/pdf
+                      - url: 'https://esempio.com/immagini/danno.jpg'
+                        mime_type: image/jpeg
 servers:
   - url: 'https://api.app-quality.com'
 tags:

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_patch/index.spec.ts
@@ -108,23 +108,25 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     await tryber.tables.WpAppqEvdProfile.do().delete();
   });
 
-  const validPayload = {
-    description: "Riparazione hardware ufficio",
-    type_id: 3,
-    cost_id: 1,
-    supplier_id: 105,
-    cost: 250.5,
-    attachments: [
-      {
-        url: "https://esempio.com/documenti/fattura.pdf",
-        mime_type: "application/pdf",
-      },
-      {
-        url: "https://esempio.com/immagini/danno.jpg",
-        mime_type: "image/jpeg",
-      },
-    ],
-  };
+  const validPayload = [
+    {
+      description: "Riparazione hardware ufficio",
+      type_id: 3,
+      cost_id: 1,
+      supplier_id: 105,
+      cost: 250.5,
+      attachments: [
+        {
+          url: "https://esempio.com/documenti/fattura.pdf",
+          mime_type: "application/pdf",
+        },
+        {
+          url: "https://esempio.com/immagini/danno.jpg",
+          mime_type: "image/jpeg",
+        },
+      ],
+    },
+  ];
 
   describe("Authentication and Authorization", () => {
     beforeEach(async () => {
@@ -190,12 +192,32 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
       });
     });
 
+    it("Should return 400 if body is not an array", async () => {
+      const response = await request(app)
+        .patch("/campaigns/1/finance/otherCosts")
+        .send(validPayload[0])
+        .set("Authorization", "Bearer admin");
+      expect(response.status).toBe(400);
+      expect(response.body.err).toBeDefined();
+    });
+
+    it("Should return 400 if array is empty", async () => {
+      const response = await request(app)
+        .patch("/campaigns/1/finance/otherCosts")
+        .send([])
+        .set("Authorization", "Bearer admin");
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe(
+        "Body must be a non-empty array of cost items"
+      );
+    });
+
     it("Should return 400 if cost_id is missing", async () => {
-      const { cost_id, ...payload } = validPayload;
+      const { cost_id, ...item } = validPayload[0];
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send(payload)
+        .send([item])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
@@ -204,7 +226,7 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     it("Should return 400 if cost_id is null", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, cost_id: null })
+        .send([{ ...validPayload[0], cost_id: null }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
@@ -213,12 +235,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     it("Should return 400 if cost_id is zero", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, cost_id: 0 })
+        .send([{ ...validPayload[0], cost_id: 0 }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "cost_id must be a positive number",
+          message: "Item 1: cost_id must be a positive number",
         })
       );
     });
@@ -226,66 +248,66 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     it("Should return 400 if cost_id is negative", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, cost_id: -1 })
+        .send([{ ...validPayload[0], cost_id: -1 }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "cost_id must be a positive number",
+          message: "Item 1: cost_id must be a positive number",
         })
       );
     });
 
     it("Should return 400 if description is missing", async () => {
-      const { description, ...payload } = validPayload;
+      const { description, ...item } = validPayload[0];
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send(payload)
+        .send([item])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
     });
 
     it("Should return 400 if type_id is missing", async () => {
-      const { type_id, ...payload } = validPayload;
+      const { type_id, ...item } = validPayload[0];
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send(payload)
+        .send([item])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
     });
 
     it("Should return 400 if supplier_id is missing", async () => {
-      const { supplier_id, ...payload } = validPayload;
+      const { supplier_id, ...item } = validPayload[0];
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send(payload)
+        .send([item])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
     });
 
     it("Should return 400 if cost is missing", async () => {
-      const { cost, ...payload } = validPayload;
+      const { cost, ...item } = validPayload[0];
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send(payload)
+        .send([item])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
     });
 
     it("Should return 400 if attachments is missing", async () => {
-      const { attachments, ...payload } = validPayload;
+      const { attachments, ...item } = validPayload[0];
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send(payload)
+        .send([item])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
@@ -294,19 +316,23 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     it("Should return 400 if attachments is an empty array", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, attachments: [] })
+        .send([{ ...validPayload[0], attachments: [] }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
-      expect(response.body.message).toBe("At least one attachment is required");
+      expect(response.body.message).toBe(
+        "Item 1: At least one attachment is required"
+      );
     });
 
     it("Should return 400 if attachments array item is missing url", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({
-          ...validPayload,
-          attachments: [{ mime_type: "application/pdf" }],
-        })
+        .send([
+          {
+            ...validPayload[0],
+            attachments: [{ mime_type: "application/pdf" }],
+          },
+        ])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
@@ -315,10 +341,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     it("Should return 400 if attachments array item is missing mime_type", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({
-          ...validPayload,
-          attachments: [{ url: "https://example.com/file.pdf" }],
-        })
+        .send([
+          {
+            ...validPayload[0],
+            attachments: [{ url: "https://example.com/file.pdf" }],
+          },
+        ])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(400);
       expect(response.body.err).toBeDefined();
@@ -329,12 +357,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
     it("Should return 404 if cost_id does not exist", async () => {
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, cost_id: 999 })
+        .send([{ ...validPayload[0], cost_id: 999 }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(404);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "Cost not found for this campaign",
+          message: "Item 1: Cost not found for this campaign",
         })
       );
     });
@@ -351,12 +379,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, cost_id: 10 })
+        .send([{ ...validPayload[0], cost_id: 10 }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(404);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "Cost not found for this campaign",
+          message: "Item 1: Cost not found for this campaign",
         })
       );
     });
@@ -373,12 +401,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, type_id: 999 })
+        .send([{ ...validPayload[0], type_id: 999 }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(404);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "Type not found",
+          message: "Item 1: Type not found",
         })
       );
     });
@@ -395,12 +423,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, supplier_id: 999 })
+        .send([{ ...validPayload[0], supplier_id: 999 }])
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(404);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "Supplier not found",
+          message: "Item 1: Supplier not found",
         })
       );
     });
@@ -422,6 +450,15 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
         .send(validPayload)
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toEqual(
+        expect.objectContaining({
+          cost_id: 1,
+          description: "Riparazione hardware ufficio",
+          cost: 250.5,
+        })
+      );
 
       const updatedCost = await tryber.tables.WpAppqCampaignOtherCosts.do()
         .where({ id: 1 })
@@ -469,6 +506,8 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
         .send(validPayload)
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
 
       const attachments =
         await tryber.tables.WpAppqCampaignOtherCostsAttachment.do()
@@ -633,16 +672,12 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
 
       const response = await request(app)
         .patch("/campaigns/1/finance/otherCosts")
-        .send({ ...validPayload, attachments: [] })
+        .send([{ ...validPayload[0], attachments: [] }])
         .set("Authorization", "Bearer admin");
-      expect(response.status).toBe(200);
-
-      const attachments =
-        await tryber.tables.WpAppqCampaignOtherCostsAttachment.do()
-          .where({ cost_id: 1 })
-          .select();
-      expect(attachments).toHaveLength(0);
-      expect(deleteFromS3).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe(
+        "Item 1: At least one attachment is required"
+      );
     });
 
     it("Should only update specified cost, not others", async () => {
@@ -670,6 +705,8 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
         .send(validPayload)
         .set("Authorization", "Bearer admin");
       expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
 
       const updatedCost = await tryber.tables.WpAppqCampaignOtherCosts.do()
         .where({ id: 1 })
@@ -697,6 +734,63 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
       expect(getResponse.status).toBe(200);
       expect(getResponse.body.items).toHaveLength(2);
     });
+
+    it("Should update multiple costs in single request", async () => {
+      await tryber.tables.WpAppqCampaignOtherCosts.do().insert([
+        {
+          id: 1,
+          campaign_id: 1,
+          description: "First cost",
+          cost: 100.0,
+          type_id: 1,
+          supplier_id: 1,
+        },
+        {
+          id: 2,
+          campaign_id: 1,
+          description: "Second cost",
+          cost: 200.0,
+          type_id: 2,
+          supplier_id: 2,
+        },
+      ]);
+
+      const response = await request(app)
+        .patch("/campaigns/1/finance/otherCosts")
+        .send([
+          validPayload[0],
+          {
+            ...validPayload[0],
+            cost_id: 2,
+            description: "Updated second cost",
+            cost: 300.0,
+          },
+        ])
+        .set("Authorization", "Bearer admin");
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(2);
+
+      const cost1 = await tryber.tables.WpAppqCampaignOtherCosts.do()
+        .where({ id: 1 })
+        .first();
+      expect(cost1).toEqual(
+        expect.objectContaining({
+          description: "Riparazione hardware ufficio",
+          cost: 250.5,
+        })
+      );
+
+      const cost2 = await tryber.tables.WpAppqCampaignOtherCosts.do()
+        .where({ id: 2 })
+        .first();
+      expect(cost2).toEqual(
+        expect.objectContaining({
+          description: "Updated second cost",
+          cost: 300.0,
+        })
+      );
+    });
   });
 
   describe("Success - olp permissions", () => {
@@ -715,6 +809,8 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
         .send(validPayload)
         .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
       expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
 
       const updatedCost = await tryber.tables.WpAppqCampaignOtherCosts.do()
         .where({ id: 1 })
@@ -757,6 +853,8 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
         .send(validPayload)
         .set("Authorization", 'Bearer tester olp {"appq_campaign":[1]}');
       expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
 
       const attachments =
         await tryber.tables.WpAppqCampaignOtherCostsAttachment.do()
@@ -808,7 +906,7 @@ describe("PATCH /campaigns/campaignId/finance/otherCosts", () => {
       expect(response.status).toBe(500);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "Error updating other cost",
+          message: "Error updating other costs",
         })
       );
     });

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_patch/index.ts
@@ -5,6 +5,15 @@ import { tryber } from "@src/features/database";
 import OpenapiError from "@src/features/OpenapiError";
 import deleteFromS3 from "@src/features/deleteFromS3";
 
+type OtherCostItem = {
+  cost_id: number;
+  description: string;
+  type_id: number;
+  supplier_id: number;
+  cost: number;
+  attachments: { url: string; mime_type: string }[];
+};
+
 export default class OtherCostsPatchRoute extends CampaignRoute<{
   response: StoplightOperations["patch-campaigns-campaign-finance-otherCosts"]["responses"]["200"]["content"]["application/json"];
   parameters: StoplightOperations["patch-campaigns-campaign-finance-otherCosts"]["parameters"]["path"];
@@ -20,32 +29,60 @@ export default class OtherCostsPatchRoute extends CampaignRoute<{
 
     const body = this.getBody();
 
-    if (body.attachments.length === 0) {
+    if (!Array.isArray(body) || body.length === 0) {
       this.setError(
         400,
-        new OpenapiError("At least one attachment is required")
+        new OpenapiError("Body must be a non-empty array of cost items")
       );
       return false;
     }
 
-    if (body.cost_id <= 0) {
-      this.setError(400, new OpenapiError("cost_id must be a positive number"));
-      return false;
-    }
+    for (const item of body) {
+      if (item.attachments.length === 0) {
+        this.setError(
+          400,
+          new OpenapiError(
+            `Item ${item.cost_id}: At least one attachment is required`
+          )
+        );
+        return false;
+      }
 
-    if (!(await this.costExistsInCampaign(body.cost_id))) {
-      this.setError(404, new OpenapiError("Cost not found for this campaign"));
-      return false;
-    }
+      if (item.cost_id <= 0) {
+        this.setError(
+          400,
+          new OpenapiError(
+            `Item ${item.cost_id}: cost_id must be a positive number`
+          )
+        );
+        return false;
+      }
 
-    if (!(await this.typeExists(body.type_id))) {
-      this.setError(404, new OpenapiError("Type not found"));
-      return false;
-    }
+      if (!(await this.costExistsInCampaign(item.cost_id))) {
+        this.setError(
+          404,
+          new OpenapiError(
+            `Item ${item.cost_id}: Cost not found for this campaign`
+          )
+        );
+        return false;
+      }
 
-    if (!(await this.supplierExists(body.supplier_id))) {
-      this.setError(404, new OpenapiError("Supplier not found"));
-      return false;
+      if (!(await this.typeExists(item.type_id))) {
+        this.setError(
+          404,
+          new OpenapiError(`Item ${item.cost_id}: Type not found`)
+        );
+        return false;
+      }
+
+      if (!(await this.supplierExists(item.supplier_id))) {
+        this.setError(
+          404,
+          new OpenapiError(`Item ${item.cost_id}: Supplier not found`)
+        );
+        return false;
+      }
     }
 
     return true;
@@ -54,14 +91,18 @@ export default class OtherCostsPatchRoute extends CampaignRoute<{
   protected async prepare(): Promise<void> {
     try {
       const body = this.getBody();
-      await this.updateOtherCost(body);
+      const updatedCosts = [];
 
-      const updatedCost = await this.getUpdatedCost(body.cost_id);
+      for (const item of body) {
+        await this.updateOtherCost(item);
+        const updatedCost = await this.getUpdatedCost(item.cost_id);
+        updatedCosts.push(updatedCost);
+      }
 
-      return this.setSuccess(200, updatedCost);
+      return this.setSuccess(200, updatedCosts);
     } catch (e) {
-      console.error("Error updating other cost: ", e);
-      return this.setError(500, new OpenapiError("Error updating other cost"));
+      console.error("Error updating other costs: ", e);
+      return this.setError(500, new OpenapiError("Error updating other costs"));
     }
   }
 
@@ -86,23 +127,21 @@ export default class OtherCostsPatchRoute extends CampaignRoute<{
     return supplier !== undefined;
   }
 
-  private async updateOtherCost(
-    body: StoplightOperations["patch-campaigns-campaign-finance-otherCosts"]["requestBody"]["content"]["application/json"]
-  ): Promise<void> {
-    await this.updateAttachments();
+  private async updateOtherCost(item: OtherCostItem): Promise<void> {
+    await this.updateAttachments(item);
 
     await tryber.tables.WpAppqCampaignOtherCosts.do()
-      .where({ id: body.cost_id })
+      .where({ id: item.cost_id })
       .update({
-        description: body.description,
-        cost: body.cost,
-        type_id: body.type_id,
-        supplier_id: body.supplier_id,
+        description: item.description,
+        cost: item.cost,
+        type_id: item.type_id,
+        supplier_id: item.supplier_id,
       });
   }
 
-  private async updateAttachments(): Promise<void> {
-    const { cost_id, attachments } = this.getBody();
+  private async updateAttachments(item: OtherCostItem): Promise<void> {
+    const { cost_id, attachments } = item;
     const existingAttachments =
       await tryber.tables.WpAppqCampaignOtherCostsAttachment.do()
         .select("id", "url", "mime_type")

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_patch/index.ts
@@ -38,12 +38,11 @@ export default class OtherCostsPatchRoute extends CampaignRoute<{
     }
 
     for (const item of body) {
+      const i = body.indexOf(item);
       if (item.attachments.length === 0) {
         this.setError(
           400,
-          new OpenapiError(
-            `Item ${item.cost_id}: At least one attachment is required`
-          )
+          new OpenapiError(`Item ${i + 1}: At least one attachment is required`)
         );
         return false;
       }
@@ -51,9 +50,7 @@ export default class OtherCostsPatchRoute extends CampaignRoute<{
       if (item.cost_id <= 0) {
         this.setError(
           400,
-          new OpenapiError(
-            `Item ${item.cost_id}: cost_id must be a positive number`
-          )
+          new OpenapiError(`Item ${i + 1}: cost_id must be a positive number`)
         );
         return false;
       }
@@ -61,25 +58,20 @@ export default class OtherCostsPatchRoute extends CampaignRoute<{
       if (!(await this.costExistsInCampaign(item.cost_id))) {
         this.setError(
           404,
-          new OpenapiError(
-            `Item ${item.cost_id}: Cost not found for this campaign`
-          )
+          new OpenapiError(`Item ${i + 1}: Cost not found for this campaign`)
         );
         return false;
       }
 
       if (!(await this.typeExists(item.type_id))) {
-        this.setError(
-          404,
-          new OpenapiError(`Item ${item.cost_id}: Type not found`)
-        );
+        this.setError(404, new OpenapiError(`Item ${i + 1}: Type not found`));
         return false;
       }
 
       if (!(await this.supplierExists(item.supplier_id))) {
         this.setError(
           404,
-          new OpenapiError(`Item ${item.cost_id}: Supplier not found`)
+          new OpenapiError(`Item ${i + 1}: Supplier not found`)
         );
         return false;
       }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5697,7 +5697,7 @@ export interface operations {
             url: string;
             mime_type: string;
           }[];
-        };
+        }[];
       };
     };
   };
@@ -5747,7 +5747,7 @@ export interface operations {
               url: string;
               mime_type: string;
             }[];
-          };
+          }[];
         };
       };
       /** Bad Request */
@@ -5770,7 +5770,7 @@ export interface operations {
             mime_type: string;
           }[];
           cost_id: number;
-        };
+        }[];
       };
     };
   };


### PR DESCRIPTION
This pull request updates the PATCH endpoint for `/campaigns/:campaignId/finance/otherCosts` to support bulk updates of multiple cost items in a single request. The OpenAPI documentation and test suite have been updated to reflect and validate the new array-based request and response structure. Validation and error handling are now performed per item, with improved error messages for batch operations.

**Bulk Update Support and Validation Improvements:**

* The PATCH endpoint now expects and returns an array of cost items, enabling bulk updates in a single request. The OpenAPI schema and example payloads have been updated accordingly. [[1]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13603-R13604) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dL13645-R13647) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13702-R13703) [[4]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dL13750-R13754) [[5]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13779-R13780) [[6]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dL13822-R13828)
* Validation logic has been enhanced to check that the request body is a non-empty array, and to validate each item individually, returning specific error messages that indicate the index of the invalid item (e.g., "Item 1: cost_id must be a positive number"). [[1]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R195-R220) [[2]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L207-R229) [[3]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L216-R310) [[4]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L297-R335) [[5]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L318-R349) [[6]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L332-R365) [[7]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L354-R387) [[8]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L376-R409) [[9]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L398-R431) [[10]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L636-R680)

**Test Suite Updates:**

* The test payloads have been refactored to use arrays, and new tests have been added to cover scenarios such as sending a non-array body, empty arrays, and updating multiple costs in a single request. [[1]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L111-R112) [[2]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705L127-R129) [[3]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R737-R793)
* Tests now verify that the response is an array of updated items, and that error messages are specific to the item index in batch operations. [[1]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R453-R461) [[2]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R509-R510) [[3]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R708-R709) [[4]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R812-R813) [[5]](diffhunk://#diff-39064dccba9a36acf3710c13d1b4f4c36e45e20afa2077b4c712d471aa1b0705R856-R857)

These changes ensure the API is more flexible and robust for clients needing to update multiple cost items at once, with clearer feedback on any validation issues.