### PR TITLE
Add presign url get other costs

### DIFF
--- a/src/features/s3/presignUrl/index.ts
+++ b/src/features/s3/presignUrl/index.ts
@@ -4,8 +4,11 @@ import { parseUrl } from "@aws-sdk/url-parser";
 import { Hash } from "@aws-sdk/hash-node";
 import { formatUrl } from "@aws-sdk/util-format-url";
 
-export const getPresignedUrl = async (url: string): Promise<string> => {
-  const expirationSeconds = 1200; // 20 minutes
+// default expiration is 20 minutes (1200 seconds)
+export const getPresignedUrl = async (
+  url: string,
+  expirationSeconds: number = 1200
+): Promise<string> => {
   const s3ObjectUrl = parseUrl(url);
   const presigner = new S3RequestPresigner({
     credentials: {

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -13533,6 +13533,7 @@ paths:
                               - id
                               - url
                               - mimetype
+                              - presigned_url
                             properties:
                               id:
                                 type: number
@@ -13546,6 +13547,10 @@ paths:
                                 type: string
                                 x-stoplight:
                                   id: 6tqj2cg96280v
+                              presigned_url:
+                                type: string
+                                x-stoplight:
+                                  id: 8zt5euhrtitz3
                         cost:
                           type: number
                           x-stoplight:

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
@@ -1,8 +1,22 @@
 import request from "supertest";
 import app from "@src/app";
 import { tryber } from "@src/features/database";
+import { getPresignedUrl } from "@src/features/s3/presignUrl";
+
+jest.mock("@src/features/s3/presignUrl");
+
+const mockedGetPresignedUrl = getPresignedUrl as jest.MockedFunction<
+  typeof getPresignedUrl
+>;
 
 describe("GET /campaigns/campaignId/finance/otherCosts", () => {
+  beforeEach(() => {
+    mockedGetPresignedUrl.mockImplementation(async (url: string) => url);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   beforeAll(async () => {
     await tryber.tables.WpAppqEvdProfile.do().insert([
       {
@@ -176,11 +190,13 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
                 id: 1,
                 url: "https://example.com/attachment1.pdf",
                 mimetype: "application/pdf",
+                presigned_url: expect.any(String),
               }),
               expect.objectContaining({
                 id: 2,
                 url: "https://example.com/attachment2.jpg",
                 mimetype: "image/jpeg",
+                presigned_url: expect.any(String),
               }),
             ]),
           }),
@@ -201,6 +217,7 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
                 id: 3,
                 url: "https://example.com/attachment3.png",
                 mimetype: "image/png",
+                presigned_url: expect.any(String),
               }),
             ]),
           }),
@@ -230,6 +247,20 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
               id: 1,
             },
             description: "Cost 1 description",
+            attachments: expect.arrayContaining([
+              expect.objectContaining({
+                id: 1,
+                url: "https://example.com/attachment1.pdf",
+                mimetype: "application/pdf",
+                presigned_url: expect.any(String),
+              }),
+              expect.objectContaining({
+                id: 2,
+                url: "https://example.com/attachment2.jpg",
+                mimetype: "image/jpeg",
+                presigned_url: expect.any(String),
+              }),
+            ]),
           }),
           expect.objectContaining({
             cost_id: 2,
@@ -243,6 +274,14 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
               id: 2,
             },
             description: "Cost 2 description",
+            attachments: expect.arrayContaining([
+              expect.objectContaining({
+                id: 3,
+                url: "https://example.com/attachment3.png",
+                mimetype: "image/png",
+                presigned_url: expect.any(String),
+              }),
+            ]),
           }),
         ]),
       })
@@ -306,5 +345,25 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
     expect(costWithoutAttachments).toBeDefined();
     expect(costWithoutAttachments.cost).toBe(50);
     expect(costWithoutAttachments.attachments).toEqual([]);
+  });
+
+  it("Should call getPresignedUrl for each attachment with 3 hours expiration", async () => {
+    await request(app)
+      .get("/campaigns/1/finance/otherCosts")
+      .set("Authorization", "Bearer admin");
+
+    expect(mockedGetPresignedUrl).toHaveBeenCalledTimes(3);
+    expect(mockedGetPresignedUrl).toHaveBeenCalledWith(
+      "https://example.com/attachment1.pdf",
+      10800
+    );
+    expect(mockedGetPresignedUrl).toHaveBeenCalledWith(
+      "https://example.com/attachment2.jpg",
+      10800
+    );
+    expect(mockedGetPresignedUrl).toHaveBeenCalledWith(
+      "https://example.com/attachment3.png",
+      10800
+    );
   });
 });

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.spec.ts
@@ -3,17 +3,15 @@ import app from "@src/app";
 import { tryber } from "@src/features/database";
 import { getPresignedUrl } from "@src/features/s3/presignUrl";
 
-jest.mock("@src/features/s3/presignUrl");
-
-const mockedGetPresignedUrl = getPresignedUrl as jest.MockedFunction<
-  typeof getPresignedUrl
->;
+jest.mock("@src/features/s3/presignUrl", () => {
+  return {
+    getPresignedUrl: jest
+      .fn()
+      .mockImplementation((url: string) => Promise.resolve(url)),
+  };
+});
 
 describe("GET /campaigns/campaignId/finance/otherCosts", () => {
-  beforeEach(() => {
-    mockedGetPresignedUrl.mockImplementation(async (url: string) => url);
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -347,21 +345,21 @@ describe("GET /campaigns/campaignId/finance/otherCosts", () => {
     expect(costWithoutAttachments.attachments).toEqual([]);
   });
 
-  it("Should call getPresignedUrl for each attachment with 3 hours expiration", async () => {
+  it("Should call getPresignedUrl for each attachment", async () => {
     await request(app)
       .get("/campaigns/1/finance/otherCosts")
       .set("Authorization", "Bearer admin");
 
-    expect(mockedGetPresignedUrl).toHaveBeenCalledTimes(3);
-    expect(mockedGetPresignedUrl).toHaveBeenCalledWith(
+    expect(getPresignedUrl).toHaveBeenCalledTimes(3);
+    expect(getPresignedUrl).toHaveBeenCalledWith(
       "https://example.com/attachment1.pdf",
       10800
     );
-    expect(mockedGetPresignedUrl).toHaveBeenCalledWith(
+    expect(getPresignedUrl).toHaveBeenCalledWith(
       "https://example.com/attachment2.jpg",
       10800
     );
-    expect(mockedGetPresignedUrl).toHaveBeenCalledWith(
+    expect(getPresignedUrl).toHaveBeenCalledWith(
       "https://example.com/attachment3.png",
       10800
     );

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
@@ -88,12 +88,23 @@ export default class OtherCostsRoute extends CampaignRoute<{
         );
 
         const resolvedAttachments = await Promise.all(
-          costAttachments.map(async (a) => ({
-            id: a.id,
-            url: a.url,
-            mimetype: a.mime_type,
-            presigned_url: await getPresignedUrl(a.url, 10800), // 3 hours expiration
-          }))
+          costAttachments.map(async (a) => {
+            let presignedUrl = a.url;
+            try {
+              presignedUrl = await getPresignedUrl(a.url, 10800);
+            } catch (error) {
+              console.error(
+                `Failed to generate presigned URL for ${a.url}:`,
+                error
+              );
+            }
+            return {
+              id: a.id,
+              url: a.url,
+              mimetype: a.mime_type,
+              presigned_url: presignedUrl,
+            };
+          })
         );
 
         return {

--- a/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
+++ b/src/routes/campaigns/campaignId/finance/otherCosts/_get/index.ts
@@ -3,6 +3,7 @@
 import CampaignRoute from "@src/features/routes/CampaignRoute";
 import { tryber } from "@src/features/database";
 import OpenapiError from "@src/features/OpenapiError";
+import { getPresignedUrl } from "@src/features/s3/presignUrl";
 
 type OtherCost = {
   cost_id: number;
@@ -20,6 +21,7 @@ type OtherCost = {
     id: number;
     url: string;
     mimetype: string;
+    presigned_url: string;
   }[];
 };
 
@@ -77,31 +79,38 @@ export default class OtherCostsRoute extends CampaignRoute<{
         .select("id", "url", "mime_type", "cost_id")
         .whereIn("cost_id", costIds);
 
-    return costs.map((cost) => {
-      const type = types.find((t) => t.id === cost.type_id);
-      const supplier = suppliers.find((s) => s.id === cost.supplier_id);
-      const costAttachments = attachments.filter(
-        (a) => a.cost_id === cost.cost_id
-      );
+    return Promise.all(
+      costs.map(async (cost) => {
+        const type = types.find((t) => t.id === cost.type_id);
+        const supplier = suppliers.find((s) => s.id === cost.supplier_id);
+        const costAttachments = attachments.filter(
+          (a) => a.cost_id === cost.cost_id
+        );
 
-      return {
-        cost_id: cost.cost_id,
-        cost: cost.cost,
-        type: {
-          name: type?.name || "",
-          id: type?.id || 0,
-        },
-        supplier: {
-          name: supplier?.name || "",
-          id: supplier?.id || 0,
-        },
-        description: cost.description,
-        attachments: costAttachments.map((a) => ({
-          id: a.id,
-          url: a.url,
-          mimetype: a.mime_type,
-        })),
-      };
-    });
+        const resolvedAttachments = await Promise.all(
+          costAttachments.map(async (a) => ({
+            id: a.id,
+            url: a.url,
+            mimetype: a.mime_type,
+            presigned_url: await getPresignedUrl(a.url, 10800), // 3 hours expiration
+          }))
+        );
+
+        return {
+          cost_id: cost.cost_id,
+          cost: cost.cost,
+          type: {
+            name: type?.name || "",
+            id: type?.id || 0,
+          },
+          supplier: {
+            name: supplier?.name || "",
+            id: supplier?.id || 0,
+          },
+          description: cost.description,
+          attachments: resolvedAttachments,
+        };
+      })
+    );
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5654,6 +5654,7 @@ export interface operations {
                 id: number;
                 url: string;
                 mimetype: string;
+                presigned_url: string;
               }[];
               cost: number;
             }[];


### PR DESCRIPTION
This pull request enhances the API for campaign finance "other costs" by adding presigned S3 URLs to each attachment, improving secure access to files. It updates both the backend logic and the OpenAPI schema, and introduces comprehensive tests to ensure correct behavior.

**API and Schema Enhancements:**

* Each attachment in the "other costs" API response now includes a `presigned_url` property, allowing secure, time-limited access to S3 files. [[1]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabR24) [[2]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13536) [[3]](diffhunk://#diff-d59ae4bdf1ca7e47b070e297df15db03fd89ca02f8f97a4c1ee5022d6f1bce2dR13550-R13553) [[4]](diffhunk://#diff-1b1f8e32f0a3581b6418901d5ef0e1de13b840515925f11e9ada1a2b4693149bR5657)

**Backend Logic Improvements:**

* The `getPresignedUrl` function now accepts a configurable expiration time (default 20 minutes), and is used to generate presigned URLs for each attachment with a 3-hour expiration in the route handler. [[1]](diffhunk://#diff-fdb6838951ac7a3503898154252f713877ea1a287b4d11e5db7dc7a3e18b7a66L7-R11) [[2]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabL80-R98) [[3]](diffhunk://#diff-31ee2ec1ac4fe3d962865d6c6175e059d933638145a597e86af7f9893d541fabL99-R114)

**Testing Updates:**

* The test suite for the "other costs" endpoint was updated to:
  - Mock the `getPresignedUrl` function for predictable results.
  - Assert that each attachment includes a `presigned_url` in the response. [[1]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR193-R199) [[2]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR220) [[3]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR250-R263) [[4]](diffhunk://#diff-38ec54943388b6406ce6b5765093e3af3db20c6bb6540a6b82f075c5f4b9f74fR277-R284)
  - Verify that `getPresignedUrl` is called with the correct parameters for each attachment and the intended expiration time.