### PR TITLE
UN-2381 - Add autoApprove to GET /users/me/campaigns/{campaignId}

### DIFF
--- a/src/features/class/Campaign.ts
+++ b/src/features/class/Campaign.ts
@@ -15,6 +15,7 @@ class Campaign {
   public id: number;
   public title: string = "";
   public min_allowed_media: number = 0;
+  public auto_approve: 0 | 1 = 0;
   public campaign_type: -1 | 0 | 1 = 0;
   public bug_lang: 0 | 1 = 0;
   public end_date: string = "";
@@ -39,6 +40,7 @@ class Campaign {
           "id",
           "title",
           "min_allowed_media",
+          "auto_approve",
           "campaign_type",
           "bug_lang",
           tryber.fn.charDate("end_date"),
@@ -53,6 +55,7 @@ class Campaign {
       }
       this.title = campaignData.title;
       this.min_allowed_media = campaignData.min_allowed_media;
+      this.auto_approve = campaignData.auto_approve as 0 | 1;
       this.campaign_type = campaignData.campaign_type as 0 | 1 | -1;
       this.bug_lang = campaignData.bug_lang as 0 | 1;
       this.end_date = campaignData.end_date;
@@ -193,7 +196,7 @@ class Campaign {
           "id",
           "name",
         ])
-      ).map((s: typeof replicabilities[0]) => ({
+      ).map((s: (typeof replicabilities)[0]) => ({
         ...s,
         name: s.name.toUpperCase(),
       }));

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -9521,6 +9521,7 @@ paths:
                         regex: '[A-Z]{3}[0-9]{4}'
                         slug: codice-cliente
                         type: text
+                    autoApprove: 0
                     bugReplicability:
                       invalid:
                         - ONCE
@@ -9588,6 +9589,7 @@ paths:
                       - mp4
                 with-bugform-disabled:
                   value:
+                    autoApprove: 0
                     bugReplicability:
                       invalid: []
                       valid:
@@ -9628,6 +9630,7 @@ paths:
                       - mp4
                 with-only-one-device:
                   value:
+                    autoApprove: 0
                     bugReplicability:
                       invalid: []
                       valid:
@@ -9682,6 +9685,7 @@ paths:
                       - mp4
                 without-device:
                   value:
+                    autoApprove: 0
                     bugReplicability:
                       invalid: []
                       valid:
@@ -9729,6 +9733,11 @@ paths:
                     items:
                       $ref: '#/components/schemas/CampaignAdditionalField'
                     type: array
+                  autoApprove:
+                    default: 0
+                    maximum: 1
+                    minimum: 0
+                    type: integer
                   bugReplicability:
                     properties:
                       invalid:
@@ -9840,6 +9849,7 @@ paths:
                       type: string
                     type: array
                 required:
+                  - autoApprove
                   - bugReplicability
                   - bugSeverity
                   - bugTypes

--- a/src/routes/users/me/campaigns/campaignId/_get/index.spec.ts
+++ b/src/routes/users/me/campaigns/campaignId/_get/index.spec.ts
@@ -40,6 +40,7 @@ describe("Route GET /users/me/campaigns/{campaignId}/", () => {
       id: 1,
       title: "My campaign",
       minimumMedia: 4,
+      autoApprove: 0,
       hasBugForm: true,
       hasBugParade: 0,
       bugSeverity: { valid: ["LOW", "MEDIUM"], invalid: [] },
@@ -408,6 +409,39 @@ describe("Route GET /users/me/campaigns/{campaignId}/ - title rule set", () => {
       .set("Authorization", "Bearer tester");
     expect(response.body).toMatchObject({
       titleRule: true,
+    });
+  });
+});
+
+describe("Route GET /users/me/campaigns/{campaignId}/ - autoApprove", () => {
+  useBasicData();
+  it("Should return autoApprove: 0 by default", async () => {
+    const response = await request(app)
+      .get("/users/me/campaigns/1")
+      .set("Authorization", "Bearer tester");
+    expect(response.body).toMatchObject({
+      autoApprove: 0,
+    });
+  });
+
+  describe("when campaign has auto_approve = 1", () => {
+    beforeAll(async () => {
+      await tryber.tables.WpAppqEvdCampaign.do()
+        .update({ auto_approve: 1 })
+        .where({ id: 1 });
+    });
+    afterAll(async () => {
+      await tryber.tables.WpAppqEvdCampaign.do()
+        .update({ auto_approve: 0 })
+        .where({ id: 1 });
+    });
+    it("Should return autoApprove: 1", async () => {
+      const response = await request(app)
+        .get("/users/me/campaigns/1")
+        .set("Authorization", "Bearer tester");
+      expect(response.body).toMatchObject({
+        autoApprove: 1,
+      });
     });
   });
 });

--- a/src/routes/users/me/campaigns/campaignId/_get/index.ts
+++ b/src/routes/users/me/campaigns/campaignId/_get/index.ts
@@ -76,6 +76,7 @@ export default class UserSingleCampaignRoute extends UserRoute<{
         id: campaign.id,
         title: campaign.title,
         minimumMedia: campaign.min_allowed_media,
+        autoApprove: campaign.auto_approve,
         hasBugForm: campaign.hasBugForm,
         hasBugParade: campaign.hasBugParade ? campaign.hasBugParade : 0,
         bugSeverity: await campaign.getAvailableSeverities(),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -4327,6 +4327,8 @@ export interface operations {
         content: {
           "application/json": {
             additionalFields?: components["schemas"]["CampaignAdditionalField"][];
+            /** @default 0 */
+            autoApprove: number;
             bugReplicability: {
               invalid: string[];
               valid: string[];


### PR DESCRIPTION
## Summary
- Aggiunge il campo `auto_approve` alla classe `Campaign` (property, SELECT, assegnazione)
- Espone `autoApprove` nella risposta di `GET /users/me/campaigns/{campaignId}`
- Aggiorna schema OpenAPI e tipi TypeScript generati
- Aggiunge test per `autoApprove: 0` (default) e `autoApprove: 1`

## Test plan
- [x] `npm run test -- src/routes/users/me/campaigns/campaignId/_get/index.spec.ts`